### PR TITLE
Add ordering of parameters to AddCommand's regex format

### DIFF
--- a/src/main/java/seedu/binbash/command/AddCommand.java
+++ b/src/main/java/seedu/binbash/command/AddCommand.java
@@ -5,30 +5,38 @@ import seedu.binbash.ItemList;
 
 public class AddCommand extends Command {
 
-//    public static final Pattern COMMAND_FORMAT = Pattern.compile(
-//            "add\\s" + "n/(?<itemName>.+?)\\s" + "d/(?<itemDescription>.+?)\\s" + "(q/(?<itemQuantity>.+?))?"
-//                    + "(e/(?<itemExpirationDate>.+?))?" + "s/(?<itemSalePrice>.+?)\\s" + "c/(?<itemCostPrice>.+)"
-//    );
+
+    //    public static final Pattern COMMAND_FORMAT = Pattern.compile(
+    //            "add\\s" + "n/(?<itemName>.+?)\\s" + "d/(?<itemDescription>.+?)\\s" + "(q/(?<itemQuantity>.+?))?"
+    //                    + "(e/(?<itemExpirationDate>.+?))?" + "s/(?<itemSalePrice>.+?)\\s" + "c/(?<itemCostPrice>.+)"
+    //    );
 
     /**
-     * TODO: I understand the formatting of this is cancer. The trailing comments are exceeding the wraparound
-     * TODO: limit. We have to fix it in the future, but I hope they help clarify the regex for future rectifications.
+     * TODO: I understand the formatting of this is cancer. I'll fix it in the future, but I hope they help clarify
+     * TODO: the regex format for future rectifications.
      *
      * As of now, only itemQuantity(q/) and and itemExpirationDate(e/) are optional groups.
      */
     public static final Pattern COMMAND_FORMAT = Pattern.compile(
 
-            "add\\s+" +                                             // Match the 'add' command followed by one or more whitespace characters.
+            "add\\s+" +                                             // Match the 'add' command followed by one or more
+                                                                    // whitespace characters.
 
-                    "n/(?<itemName>.+?)(?=d/)" +                    // Match 'n/' followed by any characters for `itemName`, lazy match, until seeing 'd/'.
+                    "n/(?<itemName>.+?)(?=d/)" +                    // Match 'n/' followed by any characters for
+                                                                    // `itemName`, lazy match, until seeing 'd/'.
 
-                    "d/(?<itemDescription>.+?)(?=(q/|e/|s/))" +     // Match 'd/' followed by any characters for `itemDescription`, lazy match, until seeing 'q/', 'e/', or 's/'.
+                    "d/(?<itemDescription>.+?)(?=(q/|e/|s/))" +     // Match 'd/' followed by any characters for
+                                                                    // `itemDescription`, lazy match, until seeing
+                                                                    // 'q/', 'e/', or 's/'.
 
-                    "(q/(?<itemQuantity>.+?)(?=(e/|s/)))?\\s*" +    // Optionally match 'q/' followed by the item quantity.
+                    "(q/(?<itemQuantity>.+?)(?=(e/|s/)))?\\s*" +    // Optionally match 'q/' followed by the
+                                                                    // item quantity.
 
-                    "(e/(?<itemExpirationDate>.+?)(?=s/))?\\s*" +   // Optionally match 'e/' followed by the expiration date.
+                    "(e/(?<itemExpirationDate>.+?)(?=s/))?\\s*" +   // Optionally match 'e/' followed by the
+                                                                    // expiration date.
 
-                    "(s/(?<itemSalePrice>.+?))(?=c/)" +             // Match 's/' followed by the sale price, until seeing 'c/'.
+                    "(s/(?<itemSalePrice>.+?))(?=c/)" +             // Match 's/' followed by the sale price, until
+                                                                    // seeing 'c/'.
 
                     "c/(?<itemCostPrice>.+)"                        // Finally, match 'c/' followed by the cost price.
     );

--- a/src/main/java/seedu/binbash/command/AddCommand.java
+++ b/src/main/java/seedu/binbash/command/AddCommand.java
@@ -19,29 +19,28 @@ public class AddCommand extends Command {
      */
     public static final Pattern COMMAND_FORMAT = Pattern.compile(
 
-            "add\\s+" +                                             // Match the 'add' command followed by one or more
-                                                                    // whitespace characters.
+            // Match the 'add' command followed by one or more whitespace characters.
+            "add\\s+" +
 
-                    "n/(?<itemName>.+?)(?=d/)" +                    // Match 'n/' followed by any characters for
-                                                                    // `itemName`, lazy match, until seeing 'd/'.
+                    // Match 'n/' followed by any characters for `itemName`, lazy match, until seeing 'd/'.
+                    "n/(?<itemName>.+?)(?=d/)" +
 
-                    "d/(?<itemDescription>.+?)(?=(q/|e/|s/))" +     // Match 'd/' followed by any characters for
-                                                                    // `itemDescription`, lazy match, until seeing
-                                                                    // 'q/', 'e/', or 's/'.
+                    // Match 'd/' followed by any characters for `itemDescription`, lazy match, until seeing
+                    // 'q/', 'e/', or 's/'.
+                    "d/(?<itemDescription>.+?)(?=(q/|e/|s/))" +
+                    
+                    // Optionally match 'q/' followed by the item quantity.
+                    "(q/(?<itemQuantity>.+?)(?=(e/|s/)))?\\s*" +
 
-                    "(q/(?<itemQuantity>.+?)(?=(e/|s/)))?\\s*" +    // Optionally match 'q/' followed by the
-                                                                    // item quantity.
+                    // Optionally match 'e/' followed by the expiration date.
+                    "(e/(?<itemExpirationDate>.+?)(?=s/))?\\s*" +
 
-                    "(e/(?<itemExpirationDate>.+?)(?=s/))?\\s*" +   // Optionally match 'e/' followed by the
-                                                                    // expiration date.
+                    // Match 's/' followed by the sale price, until seeing 'c/'.
+                    "(s/(?<itemSalePrice>.+?))(?=c/)" +
 
-                    "(s/(?<itemSalePrice>.+?))(?=c/)" +             // Match 's/' followed by the sale price, until
-                                                                    // seeing 'c/'.
-
-                    "c/(?<itemCostPrice>.+)"                        // Finally, match 'c/' followed by the cost price.
+                    // Finally, match 'c/' followed by the cost price.
+                    "c/(?<itemCostPrice>.+)"
     );
-
-
     private final String itemName;
     private final String itemDescription;
     private final int itemQuantity;

--- a/src/main/java/seedu/binbash/command/AddCommand.java
+++ b/src/main/java/seedu/binbash/command/AddCommand.java
@@ -5,10 +5,35 @@ import seedu.binbash.ItemList;
 
 public class AddCommand extends Command {
 
+//    public static final Pattern COMMAND_FORMAT = Pattern.compile(
+//            "add\\s" + "n/(?<itemName>.+?)\\s" + "d/(?<itemDescription>.+?)\\s" + "(q/(?<itemQuantity>.+?))?"
+//                    + "(e/(?<itemExpirationDate>.+?))?" + "s/(?<itemSalePrice>.+?)\\s" + "c/(?<itemCostPrice>.+)"
+//    );
+
+    /**
+     * TODO: I understand the formatting of this is cancer. The trailing comments are exceeding the wraparound
+     * TODO: limit. We have to fix it in the future, but I hope they help clarify the regex for future rectifications.
+     *
+     * As of now, only itemQuantity(q/) and and itemExpirationDate(e/) are optional groups.
+     */
     public static final Pattern COMMAND_FORMAT = Pattern.compile(
-            "add\\s" + "n/(?<itemName>.+?)\\s" + "d/(?<itemDescription>.+?)\\s" + "(q/(?<itemQuantity>.+?))?"
-                    + "(e/(?<itemExpirationDate>.+?))?" + "s/(?<itemSalePrice>.+?)\\s" + "c/(?<itemCostPrice>.+)"
+
+            "add\\s+" +                                             // Match the 'add' command followed by one or more whitespace characters.
+
+                    "n/(?<itemName>.+?)(?=d/)" +                    // Match 'n/' followed by any characters for `itemName`, lazy match, until seeing 'd/'.
+
+                    "d/(?<itemDescription>.+?)(?=(q/|e/|s/))" +     // Match 'd/' followed by any characters for `itemDescription`, lazy match, until seeing 'q/', 'e/', or 's/'.
+
+                    "(q/(?<itemQuantity>.+?)(?=(e/|s/)))?\\s*" +    // Optionally match 'q/' followed by the item quantity.
+
+                    "(e/(?<itemExpirationDate>.+?)(?=s/))?\\s*" +   // Optionally match 'e/' followed by the expiration date.
+
+                    "(s/(?<itemSalePrice>.+?))(?=c/)" +             // Match 's/' followed by the sale price, until seeing 'c/'.
+
+                    "c/(?<itemCostPrice>.+)"                        // Finally, match 'c/' followed by the cost price.
     );
+
+
     private final String itemName;
     private final String itemDescription;
     private final int itemQuantity;

--- a/src/main/java/seedu/binbash/command/AddCommand.java
+++ b/src/main/java/seedu/binbash/command/AddCommand.java
@@ -28,7 +28,7 @@ public class AddCommand extends Command {
                     // Match 'd/' followed by any characters for `itemDescription`, lazy match, until seeing
                     // 'q/', 'e/', or 's/'.
                     "d/(?<itemDescription>.+?)(?=(q/|e/|s/))" +
-                    
+
                     // Optionally match 'q/' followed by the item quantity.
                     "(q/(?<itemQuantity>.+?)(?=(e/|s/)))?\\s*" +
 

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -13,8 +13,8 @@ Welcome to BinBash!
 -------------------------------------------------------------
 Noted! I have added the following item into your inventory:
 
-item with
-	description: no exp or quantity
+item with 
+	description: no exp or quantity 
 	quantity: 0
 	expiry date: N.A.
 	sale price: $0.00
@@ -23,8 +23,8 @@ item with
 -------------------------------------------------------------
 Noted! I have added the following item into your inventory:
 
-item with
-	description: no exp
+item with 
+	description: no exp 
 	quantity: 10
 	expiry date: N.A.
 	sale price: $0.00
@@ -33,8 +33,8 @@ item with
 -------------------------------------------------------------
 Noted! I have added the following item into your inventory:
 
-item with
-	description: no quantity
+item with 
+	description: no quantity 
 	quantity: 0
 	expiry date: 01-01-1999
 	sale price: $0.00
@@ -43,37 +43,37 @@ item with
 -------------------------------------------------------------
 Noted! I have added the following item into your inventory:
 
-item with
-	description: everything
+item with 
+	description: everything 
 	quantity: 100
 	expiry date: 01-01-1999
 	sale price: $0.00
 	cost price: $100.00
 -------------------------------------------------------------
 -------------------------------------------------------------
-1. item with
-	description: no exp or quantity
+1. item with 
+	description: no exp or quantity 
 	quantity: 0
 	expiry date: N.A.
 	sale price: $0.00
 	cost price: $100.00
 
-2. item with
-	description: no exp
+2. item with 
+	description: no exp 
 	quantity: 10
 	expiry date: N.A.
 	sale price: $0.00
 	cost price: $100.00
 
-3. item with
-	description: no quantity
+3. item with 
+	description: no quantity 
 	quantity: 0
 	expiry date: 01-01-1999
 	sale price: $0.00
 	cost price: $100.00
 
-4. item with
-	description: everything
+4. item with 
+	description: everything 
 	quantity: 100
 	expiry date: 01-01-1999
 	sale price: $0.00


### PR DESCRIPTION
Given our current Add Command format,

`add n/ITEM_NAME d/ITEM_DESCRIPTION q/ITEM_QUANTITY e/EXPIRATION_DATE s/SALE_PRICE c/COST_PRICE`

I have added lookahead assertions ('?=') as a way to add some sort of 'ordering' to the flags. One example would be after the n/ flag, characters would be read up to the 'd/' flag, and if no such flag is present, it would be deemed as an invalid command.

However, there are still errors, and they tend to appear near optional flags. (You may try it for yourself, swap the q/ and e/ flag, and the matcher would still match.)
 
@YHWong20 I blanked out your original Add Command format and left it there in case mine causes any unexpected breaks. If it does, feel free to revert to yours.
 
 
 
Also, let's discuss if we would like to continue using Regex, or another method to parse Add Commands, given that we are planning to make the last 4 parameters optional.

One alternative I can suggest would be, sadly, through the use of substrings. Each flag (eg. n/ d/ q/) can be defined as a constant, having a specific index, through the use of indexOf(). The following conditions can then be checked:

- Each flag appears only once in the entire String. ( 0 or 1 for optional flags)
- The indexes must be strictly increasing, to ensure proper ordering of parameters

After each parameter has been extracted, further checks can then be done on the individual parameters, such as a valid integer, float, etc.


