### PR TITLE
Add logic to allow creation of Operational Items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ bin/
 /text-ui-test/ACTUAL.TXT
 /text-ui-test/EXPECTED-UNIX.TXT
 /text-ui-test/data/
+/text-ui-test/logs/
 
 # Data and log files created by application
 /data/

--- a/src/main/java/seedu/binbash/ItemList.java
+++ b/src/main/java/seedu/binbash/ItemList.java
@@ -1,6 +1,8 @@
 package seedu.binbash;
 
 import seedu.binbash.item.Item;
+import seedu.binbash.item.OperationalItem;
+import seedu.binbash.item.PerishableOperationalItem;
 import seedu.binbash.item.PerishableRetailItem;
 import seedu.binbash.item.RetailItem;
 import seedu.binbash.command.RestockCommand;
@@ -76,16 +78,23 @@ public class ItemList {
         return itemList.size();
     }
 
-    public String addItem(String itemName, String itemDescription, int itemQuantity,
+    public String addItem(String itemType, String itemName, String itemDescription, int itemQuantity,
                           LocalDate itemExpirationDate, double itemSalePrice, double itemCostPrice) {
         Item item;
-        if (!itemExpirationDate.equals(LocalDate.MIN)) {
-            // Create perishable item
+        if (itemType.equals("retail") && !itemExpirationDate.equals(LocalDate.MIN)) {
+            // Perishable Retail Item
             item = new PerishableRetailItem(itemName, itemDescription, itemQuantity,
                     itemExpirationDate, itemSalePrice, itemCostPrice);
-        } else {
-            // Create non-perishable item
+        } else if (itemType.equals("retail") && itemExpirationDate.equals(LocalDate.MIN)) {
+            // Non-perishable Retail Item
             item = new RetailItem(itemName, itemDescription, itemQuantity, itemSalePrice, itemCostPrice);
+        } else if (itemType.equals("operational") && !itemExpirationDate.equals(LocalDate.MIN)) {
+            // Perishable Operational Item
+            item = new PerishableOperationalItem(itemName, itemDescription, itemQuantity,
+                    itemExpirationDate, itemCostPrice);
+        } else {
+            // Non-perishable Operational Item
+            item = new OperationalItem(itemName, itemDescription, itemQuantity, itemCostPrice);
         }
 
         int beforeSize = itemList.size();
@@ -181,7 +190,7 @@ public class ItemList {
                     + printList(filteredList);
         }
 
-        assert filteredList.size() > 0 && filteredList.size() <= itemList.size();
+        assert filteredList.size() >= 0 && filteredList.size() <= itemList.size();
         return output;
     }
 

--- a/src/main/java/seedu/binbash/command/AddCommand.java
+++ b/src/main/java/seedu/binbash/command/AddCommand.java
@@ -6,18 +6,6 @@ import seedu.binbash.ItemList;
 
 public class AddCommand extends Command {
 
-
-    //    public static final Pattern COMMAND_FORMAT = Pattern.compile(
-    //            "add\\s" + "n/(?<itemName>.+?)\\s" + "d/(?<itemDescription>.+?)\\s" + "(q/(?<itemQuantity>.+?))?"
-    //                    + "(e/(?<itemExpirationDate>.+?))?" + "s/(?<itemSalePrice>.+?)\\s" + "c/(?<itemCostPrice>.+)"
-    //    );
-
-    /**
-     * TODO: I understand the formatting of this is cancer. I'll fix it in the future, but I hope they help clarify
-     * TODO: the regex format for future rectifications.
-     *
-     * As of now, only itemQuantity(q/) and and itemExpirationDate(e/) are optional groups.
-     */
     public static final Pattern COMMAND_FORMAT = Pattern.compile(
 
             // Match the 'add' command followed by one or more whitespace characters.
@@ -42,6 +30,7 @@ public class AddCommand extends Command {
                     // Finally, match 'c/' followed by the cost price.
                     "c/(?<itemCostPrice>.+)"
     );
+    private final String itemType;
     private final String itemName;
     private final String itemDescription;
     private final int itemQuantity;
@@ -49,8 +38,9 @@ public class AddCommand extends Command {
     private final double itemSalePrice;
     private final double itemCostPrice;
 
-    public AddCommand(String itemName, String itemDescription, int itemQuantity,
+    public AddCommand(String itemType, String itemName, String itemDescription, int itemQuantity,
                       LocalDate itemExpirationDate, double itemSalePrice, double itemCostPrice) {
+        this.itemType = itemType;
         this.itemName = itemName;
         this.itemDescription = itemDescription;
         this.itemQuantity = itemQuantity;
@@ -75,7 +65,7 @@ public class AddCommand extends Command {
 
     @Override
     public boolean execute(ItemList itemList) {
-        executionUiOutput = itemList.addItem(itemName, itemDescription, itemQuantity, itemExpirationDate,
+        executionUiOutput = itemList.addItem(itemType, itemName, itemDescription, itemQuantity, itemExpirationDate,
                 itemSalePrice, itemCostPrice);
         hasToSave = true;
         return true;

--- a/src/main/java/seedu/binbash/item/PerishableOperationalItem.java
+++ b/src/main/java/seedu/binbash/item/PerishableOperationalItem.java
@@ -19,7 +19,7 @@ public class PerishableOperationalItem extends OperationalItem {
 
     @Override
     public String toString() {
-        return "[P] " + super.toString() + System.lineSeparator() +
+        return "[P]" + super.toString() + System.lineSeparator() +
                 String.format("\texpiry date: %s", itemExpirationDate.format(DATE_TIME_FORMATTER));
     }
 }

--- a/src/main/java/seedu/binbash/parser/CommandOptionAdder.java
+++ b/src/main/java/seedu/binbash/parser/CommandOptionAdder.java
@@ -1,6 +1,7 @@
 package seedu.binbash.parser;
 
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 
 public class CommandOptionAdder {
@@ -8,6 +9,40 @@ public class CommandOptionAdder {
 
     public CommandOptionAdder(Options options) {
         this.options = options;
+    }
+
+    private Option getRetailItemOption() {
+        Option reItemOption = Option.builder("re")
+                .hasArg(false)
+                .required(true)
+                .longOpt("retail")
+                .desc("Add a Retail Item.")
+                .argName("retail")
+                .build();
+
+        return reItemOption;
+    }
+
+    private Option getOperationalItemOption() {
+        Option opItemOption = Option.builder("op")
+                .hasArg(false)
+                .required(true)
+                .longOpt("operational")
+                .desc("Add an Operational Item.")
+                .argName("operational")
+                .build();
+
+        return opItemOption;
+    }
+
+    CommandOptionAdder addItemTypeOptionGroup() {
+        OptionGroup itemTypeOptionGroup = new OptionGroup()
+                .addOption(getRetailItemOption())
+                .addOption(getOperationalItemOption());
+
+        itemTypeOptionGroup.setRequired(true);
+        options.addOptionGroup(itemTypeOptionGroup);
+        return this;
     }
 
     CommandOptionAdder addNameOption(boolean isRequired, String description) {

--- a/src/test/java/seedu/binbash/ItemListTest.java
+++ b/src/test/java/seedu/binbash/ItemListTest.java
@@ -2,19 +2,22 @@ package seedu.binbash;
 
 import org.junit.jupiter.api.Test;
 import seedu.binbash.item.Item;
+import seedu.binbash.item.OperationalItem;
+import seedu.binbash.item.PerishableOperationalItem;
 import seedu.binbash.item.PerishableRetailItem;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ItemListTest {
 
     @Test
     void deleteItem_indexOfItemInItemList_itemRemovedFromItemList() {
         ItemList itemList = new ItemList(new ArrayList<Item>());
-        itemList.addItem("testItem", "A test item", 2,
+        itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00);
 
         itemList.deleteItem(1);
@@ -25,7 +28,7 @@ class ItemListTest {
     @Test
     void deleteItem_nameOfItemInItemList_itemRemovedFromItemList() {
         ItemList itemList = new ItemList(new ArrayList<Item>());
-        itemList.addItem("testItem", "A test item", 2,
+        itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00);
 
         itemList.deleteItem("testItem");
@@ -36,7 +39,7 @@ class ItemListTest {
     @Test
     void deleteItem_nameOfItemNotInItemList_itemNotRemovedFromItemList() {
         ItemList itemList = new ItemList(new ArrayList<Item>());
-        itemList.addItem("testItem", "A test item", 2,
+        itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00);
 
         itemList.deleteItem("notTestItem");
@@ -48,7 +51,7 @@ class ItemListTest {
     void addItem_noItemInItemList_oneItemInItemList() {
         ItemList itemList = new ItemList(new ArrayList<Item>());
 
-        itemList.addItem("testItem", "A test item", 2,
+        itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00);
         assertEquals(1, itemList.getItemCount());
     }
@@ -57,7 +60,7 @@ class ItemListTest {
     void addItem_itemInputs_correctItemParameters() {
         ItemList itemList = new ItemList(new ArrayList<Item>());
 
-        itemList.addItem("testItem", "A test item", 2,
+        itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.of(1999, 1, 1), 4.00, 5.00);
         PerishableRetailItem item = (PerishableRetailItem) itemList.getItemList().get(0);
 
@@ -70,12 +73,30 @@ class ItemListTest {
     }
 
     @Test
+    void addItem_addOperationalItem_correctItemType() {
+        ItemList itemList = new ItemList(new ArrayList<Item>());
+
+        itemList.addItem("operational", "testItem", "A test item", 2,
+                LocalDate.MIN, 0.00, 5.00);
+        assertTrue(itemList.getItemList().get(0) instanceof OperationalItem);
+    }
+
+    @Test
+    void addItem_addPerishableOperationalItem_correctItemType() {
+        ItemList itemList = new ItemList(new ArrayList<Item>());
+
+        itemList.addItem("operational", "testItem", "A test item", 2,
+                LocalDate.of(1999, 1, 1), 0.00, 5.00);
+        assertTrue(itemList.getItemList().get(0) instanceof PerishableOperationalItem);
+    }
+
+    @Test
     void printList_twoItemsInItemList_correctPrintFormatForBothItems() {
         ItemList itemList = new ItemList(new ArrayList<Item>());
 
-        itemList.addItem("testItem1", "Test item 1", 2,
+        itemList.addItem("retail", "testItem1", "Test item 1", 2,
                 LocalDate.of(1999, 1, 1), 4.00, 5.00);
-        itemList.addItem("testItem2", "Test item 2", 6,
+        itemList.addItem("retail", "testItem2", "Test item 2", 6,
                 LocalDate.of(1999, 1, 1), 8.00, 9.00);
 
         String actualOutput = itemList.printList(itemList.getItemList());

--- a/src/test/java/seedu/binbash/command/AddCommandTest.java
+++ b/src/test/java/seedu/binbash/command/AddCommandTest.java
@@ -14,7 +14,7 @@ public class AddCommandTest {
     @Test
     void execute_item_oneItemInItemList() {
         ItemList itemList = new ItemList(new ArrayList<Item>());
-        AddCommand addCommand = new AddCommand("testItem", "A test item", 2,
+        AddCommand addCommand = new AddCommand("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00);
 
         addCommand.execute(itemList);

--- a/src/test/java/seedu/binbash/command/DeleteCommandTest.java
+++ b/src/test/java/seedu/binbash/command/DeleteCommandTest.java
@@ -14,7 +14,7 @@ class DeleteCommandTest {
     @Test
     void execute_deleteCommandOnListWithTestItem_success() {
         ItemList itemList = new ItemList(new ArrayList<Item>());
-        itemList.addItem("testItem", "A test item", 1,
+        itemList.addItem("retail", "testItem", "A test item", 1,
                 LocalDate.now(), 10.00, 5.00);
 
         DeleteCommand deleteCommand = new DeleteCommand("testItem");

--- a/src/test/java/seedu/binbash/command/ListCommandTest.java
+++ b/src/test/java/seedu/binbash/command/ListCommandTest.java
@@ -15,9 +15,9 @@ class ListCommandTest {
     void execute_listCommandWithTwoItemsInItemList_correctPrintFormatForBothItems() {
         ItemList itemList = new ItemList(new ArrayList<Item>());
 
-        itemList.addItem("testItem1", "Test item 1", 2,
+        itemList.addItem("retail", "testItem1", "Test item 1", 2,
                 LocalDate.of(1999, 1, 1), 4.00, 5.00);
-        itemList.addItem("testItem2", "Test item 2", 6,
+        itemList.addItem("retail", "testItem2", "Test item 2", 6,
                 LocalDate.of(1999, 1, 1), 8.00, 9.00);
 
         ListCommand listCommand = new ListCommand();

--- a/src/test/java/seedu/binbash/parser/ParserTest.java
+++ b/src/test/java/seedu/binbash/parser/ParserTest.java
@@ -48,16 +48,24 @@ public class ParserTest {
 
     @Test
     public void testParseCommand_validCommandDelete_returnsDeleteCommand() throws BinBashException {
-        itemList.addItem("Test Item", "Test Description", 5, LocalDate.now(), 10.5, 7.5);
+        itemList.addItem("retail", "Test Item", "Test Description", 5, LocalDate.now(), 10.5, 7.5);
         Command command = parser.parseCommand("delete Test Item");
         assertTrue(command instanceof DeleteCommand);
     }
 
     @Test
+    public void parseAddCommand_multipleItemTypeOptions_throwsInvalidCommandException() {
+        assertThrows(
+                InvalidFormatException.class,
+                () -> parser.parseCommand("add -re -op -n Test Item -d Test Description -c 0.00")
+        );
+    }
+
+    @Test
     public void parseAddCommand_createItemWithNoQuantityAndExpirationDate_returnsAddCommand() {
         try {
-            itemList.addItem("Test Item", "Test Description", 0, LocalDate.MIN, 0.00, 0.00);
-            Command command = parser.parseCommand("add -n Test Item -d Test Description -s 0.00 -c 0.00");
+            itemList.addItem("retail", "Test Item", "Test Description", 0, LocalDate.MIN, 0.00, 0.00);
+            Command command = parser.parseCommand("add -re -n Test Item -d Test Description -s 0.00 -c 0.00");
             assertTrue(command instanceof AddCommand);
         } catch (BinBashException e) {
             fail("Unexpected exception: " + e.getMessage());
@@ -67,8 +75,10 @@ public class ParserTest {
     @Test
     public void parseAddCommand_createItemWithNoQuantity_returnsAddCommand() {
         try {
-            itemList.addItem("Test Item", "Test Description", 0, LocalDate.of(1999, 1, 1), 0.00, 0.00);
-            Command command = parser.parseCommand("add -n Test Item -d Test Description -e 01-01-1999 -s 0.00 -c 0.00");
+            itemList.addItem("retail", "Test Item", "Test Description", 0, LocalDate.of(1999, 1, 1), 0.00, 0.00);
+            Command command = parser.parseCommand(
+                    "add -re -n Test Item -d Test Description -e 01-01-1999 -s 0.00 -c 0.00"
+            );
             assertTrue(command instanceof AddCommand);
         } catch (BinBashException e) {
             fail("Unexpected exception: " + e.getMessage());
@@ -78,8 +88,8 @@ public class ParserTest {
     @Test
     public void parseAddCommand_createItemWithNoExpiration_returnsAddCommand() {
         try {
-            itemList.addItem("Test Item", "Test Description", 10, LocalDate.MIN, 0.00, 0.00);
-            Command command = parser.parseCommand("add -n Test Item -d Test Description -q 10 -s 0.00 -c 0.00");
+            itemList.addItem("retail", "Test Item", "Test Description", 10, LocalDate.MIN, 0.00, 0.00);
+            Command command = parser.parseCommand("add -re -n Test Item -d Test Description -q 10 -s 0.00 -c 0.00");
             assertTrue(command instanceof AddCommand);
         } catch (BinBashException e) {
             fail("Unexpected exception: " + e.getMessage());
@@ -89,9 +99,9 @@ public class ParserTest {
     @Test
     public void parseAddCommand_createItemWithAllArguments_returnsAddCommand() {
         try {
-            itemList.addItem("Test Item", "Test Description", 10, LocalDate.of(1999, 1, 1), 0.00, 0.00);
+            itemList.addItem("retail", "Test Item", "Test Description", 10, LocalDate.of(1999, 1, 1), 0.00, 0.00);
             Command command = parser.parseCommand(
-                    "add -n Test Item -d Test Description -q 10 -e 01-01-1999 -s 0.00 -c 0.00"
+                    "add -re -n Test Item -d Test Description -q 10 -e 01-01-1999 -s 0.00 -c 0.00"
             );
             assertTrue(command instanceof AddCommand);
         } catch (BinBashException e) {

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -56,6 +56,23 @@ Noted! I have added the following item into your inventory:
 	expiry date: 01-01-1999
 -------------------------------------------------------------
 -------------------------------------------------------------
+Noted! I have added the following item into your inventory:
+
+[O] item with
+	description: no exp(op)
+	quantity: 10
+	cost price: $100.00
+-------------------------------------------------------------
+-------------------------------------------------------------
+Noted! I have added the following item into your inventory:
+
+[P][O] item with
+	description: everything(op)
+	quantity: 100
+	cost price: $100.00
+	expiry date: 01-01-1999
+-------------------------------------------------------------
+-------------------------------------------------------------
 1. [R] item with
 	description: no exp or quantity
 	quantity: 0
@@ -80,6 +97,17 @@ Noted! I have added the following item into your inventory:
 	quantity: 100
 	cost price: $100.00
 	sale price: $0.00
+	expiry date: 01-01-1999
+
+5. [O] item with
+	description: no exp(op)
+	quantity: 10
+	cost price: $100.00
+
+6. [P][O] item with
+	description: everything(op)
+	quantity: 100
+	cost price: $100.00
 	expiry date: 01-01-1999
 
 

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -1,7 +1,9 @@
 list
-add -n item with -d no exp or quantity -s 0.00 -c 100.00
-add -n item with -d no exp -q 10 -s 0.00 -c 100.00
-add -n item with -d no quantity -e 01-01-1999 -s 0.00 -c 100.00
-add -n item with -d everything -q 100 -e 01-01-1999 -s 0.00 -c 100.00
+add -re -n item with -d no exp or quantity -s 0.00 -c 100.00
+add -re -n item with -d no exp -q 10 -s 0.00 -c 100.00
+add -re -n item with -d no quantity -e 01-01-1999 -s 0.00 -c 100.00
+add -re -n item with -d everything -q 100 -e 01-01-1999 -s 0.00 -c 100.00
+add -op -n item with -d no exp(op) -q 10 -c 100.00
+add -op -n item with -d everything(op) -q 100 -e 01-01-1999 -c 100.00
 list
 bye


### PR DESCRIPTION
* Mandatory `-re` or `-op` options must be provided at command stage, for the user to indicate whether they intend to create a `RetailItem`, or `OperationalItem`.
* Either `-re` or `-op` is allowed. Both options cannot be provided simultaneously.
* If no `itemExpirationDate` is provided, a non-perishable `OperationalItem` is created. Else, create `PerishableOperationalItem`. 