### PR TITLE
Refactor storage parsing of data file

### DIFF
--- a/src/main/java/seedu/binbash/BinBash.java
+++ b/src/main/java/seedu/binbash/BinBash.java
@@ -19,14 +19,15 @@ public class BinBash {
     public BinBash() {
         logger = new BinBashLogger(BinBash.class.getName());
         userInterface = new Ui();
+        itemList = new ItemList();
         storage = new Storage();
-        itemList = new ItemList(storage.loadData());
         inputParser = new Parser();
     }
 
     private void run() {
         logger.info("BinBash starting...");
 
+        storage.loadData(itemList);
         userInterface.greet();
         userInterface.talk(itemList.getProfitMargin());
 

--- a/src/main/java/seedu/binbash/ItemList.java
+++ b/src/main/java/seedu/binbash/ItemList.java
@@ -23,8 +23,8 @@ public class ItemList {
     private final ArrayList<Item> itemList;
     private SearchAssistant searchAssistant;
 
-    public ItemList(ArrayList<Item> itemList) {
-        this.itemList = itemList;
+    public ItemList() {
+        this.itemList = new ArrayList<Item>();
         ITEMLIST_LOGGER.setLevel(Level.WARNING);
         this.totalRevenue = 0;
         this.totalCost = 0;

--- a/src/main/java/seedu/binbash/storage/Storage.java
+++ b/src/main/java/seedu/binbash/storage/Storage.java
@@ -4,8 +4,12 @@ import org.apache.commons.cli.ParseException;
 import seedu.binbash.ItemList;
 import seedu.binbash.command.Command;
 import seedu.binbash.exceptions.InvalidCommandException;
-import seedu.binbash.item.*;
+import seedu.binbash.item.Item;
 import seedu.binbash.exceptions.BinBashException;
+import seedu.binbash.item.OperationalItem;
+import seedu.binbash.item.PerishableRetailItem;
+import seedu.binbash.item.RetailItem;
+import seedu.binbash.item.PerishableOperationalItem;
 import seedu.binbash.parser.AddCommandParser;
 
 import java.io.File;
@@ -13,7 +17,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -34,7 +40,7 @@ public class Storage {
         this.filePath = "data/items.txt";
         this.dataDirectoryPath = "./data/";
         this.dataFileName = "items.txt";
-        this.isCorrupted = false; // set to false by default}
+        this.isCorrupted = false; // set to false by default
         this.storageLogger = Logger.getLogger("storageLogger");
     }
 
@@ -43,17 +49,14 @@ public class Storage {
     //  exception is bad exception handling!
 
     /**
-     * Loads the data from the file into the itemManager and returns a list of items.
+     * Loads the data from the file into the itemManager.
      * If the data file is corrupted or an error occurs during reading, the file is marked as corrupted.
      *
      * @param itemManager The ItemList object to add loaded items to.
-     * @return A list of items loaded from the file, or null if the file is corrupted.
      * @throws RuntimeException if an error occurs during file reading.
      */
-    public ArrayList<Item> loadData(ItemList itemManager) {
+    public void loadData(ItemList itemManager) {
         storageLogger.log(Level.INFO, "Preparing to load data from storage file.");
-
-        ArrayList<Item> itemList = null;
 
         try {
             ArrayList<String> stringRepresentationOfTxtFile = readTxtFile();
@@ -62,7 +65,7 @@ public class Storage {
             isCorrupted = true;
         }
 
-        assert !isCorrupted : "data file is corrupted";
+        //assert !isCorrupted : "data file is corrupted";
 
         if (isCorrupted) {
             storageLogger.log(Level.INFO,
@@ -70,8 +73,6 @@ public class Storage {
         } else {
             storageLogger.log(Level.INFO, "Data loaded successfully.");
         }
-
-        return itemList;
     }
 
     /**
@@ -116,8 +117,6 @@ public class Storage {
      *
      * @param stringRepresentationOfTxtFile The list of strings representing each line in the text file.
      * @param itemManager The ItemList object containing the empty list of items.
-     * @throws InvalidCommandException if the command is invalid.
-     * @throws ParseException if there is an error in parsing the command arguments.
      */
     private void parseAndAddToList(ArrayList<String> stringRepresentationOfTxtFile, ItemList itemManager) {
 

--- a/src/main/java/seedu/binbash/storage/Storage.java
+++ b/src/main/java/seedu/binbash/storage/Storage.java
@@ -1,35 +1,28 @@
 package seedu.binbash.storage;
 
-import seedu.binbash.item.Item;
-import seedu.binbash.command.AddCommand;
+import org.apache.commons.cli.ParseException;
+import seedu.binbash.ItemList;
+import seedu.binbash.command.Command;
+import seedu.binbash.exceptions.InvalidCommandException;
+import seedu.binbash.item.*;
 import seedu.binbash.exceptions.BinBashException;
-import seedu.binbash.item.PerishableRetailItem;
-import seedu.binbash.item.RetailItem;
+import seedu.binbash.parser.AddCommandParser;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class Storage {
-    private static final DateTimeFormatter EXPECTED_INPUT_DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy");
-    private static final Pattern QUANTITIES_PURCHASED_AND_SOLD_FORMAT = Pattern.compile(
-            "p/(?<totalUnitsPurchased>.+?)\\s+" +
-                    "s/(?<totalUnitsSold>.+?)"
-    );
-    private static final int READ_IN_PROFIT_QUANTITIES = 0;
-    private static final int READ_IN_ITEM = 1;
+
+    private static final int READING_IN_PROFIT_QUANTITIES = 1;
+    private static final int READING_IN_ITEM = 0;
+    private static final int TOTAL_UNITS_PURCHASED_INDEX = 0;
+    private static final int TOTAL_UNITS_SOLD_INDEX = 1;
 
     protected String filePath;
     protected String dataDirectoryPath;
@@ -50,21 +43,22 @@ public class Storage {
     //  exception is bad exception handling!
 
     /**
-     * Loads the data from the file and returns a list of items.
+     * Loads the data from the file into the itemManager and returns a list of items.
      * If the data file is corrupted or an error occurs during reading, the file is marked as corrupted.
      *
-     * @return A list of items loaded from the file.
+     * @param itemManager The ItemList object to add loaded items to.
+     * @return A list of items loaded from the file, or null if the file is corrupted.
      * @throws RuntimeException if an error occurs during file reading.
      */
-    public ArrayList<Item> loadData() {
+    public ArrayList<Item> loadData(ItemList itemManager) {
         storageLogger.log(Level.INFO, "Preparing to load data from storage file.");
 
         ArrayList<Item> itemList = null;
 
         try {
             ArrayList<String> stringRepresentationOfTxtFile = readTxtFile();
-            itemList = parseAndAddToList(stringRepresentationOfTxtFile);
-        } catch (BinBashException | IOException | NumberFormatException e) {
+            parseAndAddToList(stringRepresentationOfTxtFile, itemManager);
+        } catch (BinBashException | IOException | NumberFormatException | ParseException e) {
             isCorrupted = true;
         }
 
@@ -76,7 +70,8 @@ public class Storage {
     }
 
     /**
-     * Reads the data file and returns a list of strings representing each line in the file.
+     * Reads the data file ('items.txt') and returns a list of strings representing each line in the file.
+     * If the 'data' directory or 'items.txt' file does not exist, they will be created.
      *
      * @return A list of strings, each representing a line in the data file.
      * @throws BinBashException if the directory or file cannot be created.
@@ -110,88 +105,75 @@ public class Storage {
         return dataItems;
     }
 
-    // TODO: Check if there's a better way to do this. It would be nice to use methods from the
-    //  Parser class and create AddCommand(s) so that I can call Command.execute(), but that requires
-    //  me to already have an ItemList object, which would be weird since loadData() returns an Item List.
-
-    // TODO: Perhaps I could refactor it to create an ItemList object first, then
-    //  call Storage.loadData() ?
-
     /**
-     * Parses the list of strings and converts them into a list of Item objects.
+     * Parses the string representation of the text file and adds items to the list of items.
+     * The method handles both "add" command and "setprofit" strings to populate the item list.
      *
-     * @param stringRepresentationOfTxtFile A list of strings representing the storage file.
-     * @return A list of Item objects created from the parsed data.
+     * @param stringRepresentationOfTxtFile The list of strings representing each line in the text file.
+     * @param itemManager The ItemList object containing the empty list of items.
+     * @throws InvalidCommandException if the command is invalid.
+     * @throws ParseException if there is an error in parsing the command arguments.
      */
-    private ArrayList<Item> parseAndAddToList(ArrayList<String> stringRepresentationOfTxtFile) {
-        int turn = 0;
-        ArrayList<Item> itemList = new ArrayList<Item>();
+    private void parseAndAddToList(ArrayList<String> stringRepresentationOfTxtFile, ItemList itemManager)
+            throws InvalidCommandException, ParseException {
 
-        int totalUnitsPurchased = 0;
-        int totalUnitsSold = 0;
+        AddCommandParser addCommandParser = new AddCommandParser();
+        int parseState = READING_IN_ITEM;
 
-        for (String line: stringRepresentationOfTxtFile) {
+        for (String line : stringRepresentationOfTxtFile) {
+            String[] tokens = line.trim().split("\\s+"); // Tokenize user input
+            String commandString = tokens[0].toLowerCase();
+            String[] commandArgs = Arrays.copyOfRange(tokens, 1, tokens.length); // Takes only options and arguments
 
-            if (line == null) {
-                break;
-            }
-
-            Matcher matcher;
-
-            matcher = QUANTITIES_PURCHASED_AND_SOLD_FORMAT.matcher(line);
-            if (turn == READ_IN_PROFIT_QUANTITIES && matcher.matches()) {
-                totalUnitsPurchased = Integer.parseInt(matcher.group("totalUnitsPurchased").trim());
-                totalUnitsSold = Integer.parseInt(matcher.group("totalUnitsSold").trim());
-                turn = READ_IN_ITEM;
-                continue;
-            }
-
-            matcher = AddCommand.COMMAND_FORMAT.matcher(line);
-            if (turn == READ_IN_ITEM && matcher.matches()) {
-                turn = READ_IN_PROFIT_QUANTITIES;
-                String itemName = matcher.group("itemName").strip();
-                String itemDescription = matcher.group("itemDescription").strip();
-                int itemQuantity = Integer.parseInt(
-                        Objects.requireNonNullElse(matcher.group("itemQuantity"), "0").strip()
-                );
-                LocalDate itemExpirationDate = Optional.ofNullable(matcher.group("itemExpirationDate"))
-                        .map(String::strip)
-                        .map(x -> LocalDate.parse(x, EXPECTED_INPUT_DATE_FORMAT))
-                        .orElse(LocalDate.MIN);
-                double itemSalePrice = Double.parseDouble(matcher.group("itemSalePrice"));
-                double itemCostPrice = Double.parseDouble(matcher.group("itemCostPrice"));
-
-                if (itemExpirationDate.equals(LocalDate.MIN)) {
-                    RetailItem retailItem = new RetailItem(
-                            itemName,
-                            itemDescription,
-                            itemQuantity,
-                            itemSalePrice,
-                            itemCostPrice);
-                    retailItem.setTotalUnitsSold(totalUnitsSold);
-                    retailItem.setTotalUnitsPurchased(totalUnitsPurchased);
-                    itemList.add(retailItem);
-                } else {
-                    PerishableRetailItem perishableRetailItem = new PerishableRetailItem(
-                            itemName,
-                            itemDescription,
-                            itemQuantity,
-                            itemExpirationDate,
-                            itemSalePrice,
-                            itemCostPrice);
-                    perishableRetailItem.setTotalUnitsSold(totalUnitsSold);
-                    perishableRetailItem.setTotalUnitsPurchased(totalUnitsPurchased);
-                    itemList.add(perishableRetailItem);
-                }
-            } else {
-                isCorrupted = true;
+            if ("add".equals(commandString)) {
+                assert parseState == READING_IN_ITEM;
+                handleAddCommand(addCommandParser, commandArgs, itemManager);
+                parseState = READING_IN_PROFIT_QUANTITIES;
+            } else if ("setprofit".equals(commandString)) {
+                assert parseState == READING_IN_PROFIT_QUANTITIES;
+                handleSetProfitString(commandArgs, itemManager);
+                parseState = READING_IN_ITEM;
             }
         }
-        return itemList;
     }
 
     /**
-     * Saves the list of items to the storage file.
+     * Handles the "add" command by parsing the arguments and executing the command to add an item to the item list.
+     *
+     * @param addCommandParser The parser object used to parse the add command.
+     * @param commandArgs The arguments of the add command.
+     * @param itemManager The ItemList object to which the new item is added.
+     * @throws InvalidCommandException if the command is invalid.
+     * @throws ParseException if there is an error in parsing the command arguments.
+     */
+    private void handleAddCommand(AddCommandParser addCommandParser, String[] commandArgs, ItemList itemManager)
+            throws InvalidCommandException, ParseException {
+        Command addCommand = addCommandParser.parse(commandArgs);
+        addCommand.execute(itemManager);
+    }
+
+    /**
+     * Handles the "setprofit" string by updating the profit-related properties of the most recently added item.
+     *
+     * @param commandArgs The arguments of the setprofit command.
+     * @param itemManager The ItemList object containing the recently added item.
+     */
+    private void handleSetProfitString(String[] commandArgs, ItemList itemManager) {
+        List<Item> itemList = itemManager.getItemList();
+        Item recentlyAddedItem = itemList.get(itemList.size() - 1);
+
+        String totalUnitsPurchased = commandArgs[TOTAL_UNITS_PURCHASED_INDEX];
+        recentlyAddedItem.setTotalUnitsPurchased(Integer.parseInt(totalUnitsPurchased));
+
+        if (recentlyAddedItem instanceof RetailItem) {
+            String totalUnitsSold = commandArgs[TOTAL_UNITS_SOLD_INDEX];
+            ((RetailItem) recentlyAddedItem).setTotalUnitsSold(Integer.parseInt(totalUnitsSold));
+        }
+    }
+
+
+    /**
+     * Saves the list of items to the storage file in a format suitable for loading.
      *
      * @param itemList The list of items to be saved.
      */
@@ -209,16 +191,17 @@ public class Storage {
 
     /**
      * Generates a string representation of the list of items to be saved to the file.
+     * Each item is represented in the format of an "add" command followed by a "setprofit" string.
      *
      * @param itemList The list of items to be converted into a string.
-     * @return A string representation of the list of items.
+     * @return A string representation of the list of items, suitable for saving to a file.
      */
     private static String generateTextToSave(List<Item> itemList) {
         String textToSave = "";
 
         for (Item item: itemList) {
             if (item != null) {
-                textToSave += generateCommandRepresentationOfAnItem(item)
+                textToSave += generateStorageRepresentationOfSingleItem(item)
                         + System.lineSeparator();
             }
         }
@@ -226,39 +209,50 @@ public class Storage {
     }
 
     /**
-     * Generates a string representation of a single item in the format of an add command.
+     * Generates a string representation of a single item in the format of an "add" command, followed by
+     * a "setprofit" string
      *
      * @param item The item to be converted into a string.
-     * @return A string representation of the item in the format of an add command.
+     * @return A string representation of the item, suitable for saving to a file.
      */
-    private static String generateCommandRepresentationOfAnItem(Item item) {
+    private static String generateStorageRepresentationOfSingleItem(Item item) {
         String output = "";
 
-        output += "p/" + item.getTotalUnitsPurchased() + " " + "s/";
-
-        if (item instanceof RetailItem) {
-            RetailItem retailItem = (RetailItem)item;
-            output += retailItem.getTotalUnitsSold() + System.lineSeparator();
-        } else {
-            output += "0" + System.lineSeparator();
-        }
-
-        output += "add" + " "
-                + "n/" + item.getItemName() + " "
-                + "d/" + item.getItemDescription() + " "
-                + "q/" + item.getItemQuantity() + " ";
-
-        if (item instanceof PerishableRetailItem) {
-            PerishableRetailItem perishableItem = (PerishableRetailItem) item;
-            output += "e/" + perishableItem.getItemExpirationDate() + " ";
-        }
+        output += "add "
+                + "-n " + item.getItemName() + " "
+                + "-d " + item.getItemDescription() + " "
+                + "-q " + item.getItemQuantity() + " "
+                + "-c " + item.getItemCostPrice() + " ";
 
         if (item instanceof RetailItem) {
             RetailItem retailItem = (RetailItem) item;
-            output += "s/" + retailItem.getItemSalePrice() + " ";
+            output += "-s " + retailItem.getItemSalePrice() + " "
+                    + "-re ";
         }
 
-        output += "c/" + item.getItemCostPrice();
+        if (item instanceof PerishableRetailItem) {
+            PerishableRetailItem perishableRetailItem = (PerishableRetailItem) item;
+            output += "-e " + perishableRetailItem.getItemExpirationDate() + " ";
+        }
+
+        if (item instanceof OperationalItem) {
+            output += "-op ";
+        }
+
+        if (item instanceof PerishableOperationalItem) {
+            PerishableOperationalItem perishableOperationalItem = (PerishableOperationalItem) item;
+            output += "-e " + perishableOperationalItem.getItemExpirationDate() + " ";
+        }
+
+        output += System.lineSeparator();
+
+        output += "setprofit "
+                + item.getTotalUnitsPurchased() + " ";
+
+        if (item instanceof RetailItem) {
+            RetailItem retailItem = (RetailItem) item;
+            output += retailItem.getTotalUnitsSold();
+        }
 
         return output;
     }

--- a/src/test/java/seedu/binbash/ItemListTest.java
+++ b/src/test/java/seedu/binbash/ItemListTest.java
@@ -1,13 +1,12 @@
 package seedu.binbash;
 
 import org.junit.jupiter.api.Test;
-import seedu.binbash.item.Item;
+
 import seedu.binbash.item.OperationalItem;
 import seedu.binbash.item.PerishableOperationalItem;
 import seedu.binbash.item.PerishableRetailItem;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/seedu/binbash/ItemListTest.java
+++ b/src/test/java/seedu/binbash/ItemListTest.java
@@ -16,7 +16,7 @@ class ItemListTest {
 
     @Test
     void deleteItem_indexOfItemInItemList_itemRemovedFromItemList() {
-        ItemList itemList = new ItemList(new ArrayList<Item>());
+        ItemList itemList = new ItemList();
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00);
 
@@ -27,7 +27,7 @@ class ItemListTest {
 
     @Test
     void deleteItem_nameOfItemInItemList_itemRemovedFromItemList() {
-        ItemList itemList = new ItemList(new ArrayList<Item>());
+        ItemList itemList = new ItemList();
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00);
 
@@ -38,7 +38,7 @@ class ItemListTest {
 
     @Test
     void deleteItem_nameOfItemNotInItemList_itemNotRemovedFromItemList() {
-        ItemList itemList = new ItemList(new ArrayList<Item>());
+        ItemList itemList = new ItemList();
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00);
 
@@ -49,7 +49,7 @@ class ItemListTest {
 
     @Test
     void addItem_noItemInItemList_oneItemInItemList() {
-        ItemList itemList = new ItemList(new ArrayList<Item>());
+        ItemList itemList = new ItemList();
 
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00);
@@ -58,7 +58,7 @@ class ItemListTest {
 
     @Test
     void addItem_itemInputs_correctItemParameters() {
-        ItemList itemList = new ItemList(new ArrayList<Item>());
+        ItemList itemList = new ItemList();
 
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.of(1999, 1, 1), 4.00, 5.00);
@@ -74,7 +74,7 @@ class ItemListTest {
 
     @Test
     void addItem_addOperationalItem_correctItemType() {
-        ItemList itemList = new ItemList(new ArrayList<Item>());
+        ItemList itemList = new ItemList();
 
         itemList.addItem("operational", "testItem", "A test item", 2,
                 LocalDate.MIN, 0.00, 5.00);
@@ -83,7 +83,7 @@ class ItemListTest {
 
     @Test
     void addItem_addPerishableOperationalItem_correctItemType() {
-        ItemList itemList = new ItemList(new ArrayList<Item>());
+        ItemList itemList = new ItemList();
 
         itemList.addItem("operational", "testItem", "A test item", 2,
                 LocalDate.of(1999, 1, 1), 0.00, 5.00);
@@ -92,7 +92,7 @@ class ItemListTest {
 
     @Test
     void printList_twoItemsInItemList_correctPrintFormatForBothItems() {
-        ItemList itemList = new ItemList(new ArrayList<Item>());
+        ItemList itemList = new ItemList();
 
         itemList.addItem("retail", "testItem1", "Test item 1", 2,
                 LocalDate.of(1999, 1, 1), 4.00, 5.00);

--- a/src/test/java/seedu/binbash/command/AddCommandTest.java
+++ b/src/test/java/seedu/binbash/command/AddCommandTest.java
@@ -13,7 +13,7 @@ public class AddCommandTest {
 
     @Test
     void execute_item_oneItemInItemList() {
-        ItemList itemList = new ItemList(new ArrayList<Item>());
+        ItemList itemList = new ItemList();
         AddCommand addCommand = new AddCommand("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00);
 

--- a/src/test/java/seedu/binbash/command/AddCommandTest.java
+++ b/src/test/java/seedu/binbash/command/AddCommandTest.java
@@ -1,11 +1,10 @@
 package seedu.binbash.command;
 
 import org.junit.jupiter.api.Test;
-import seedu.binbash.item.Item;
+
 import seedu.binbash.ItemList;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/src/test/java/seedu/binbash/command/DeleteCommandTest.java
+++ b/src/test/java/seedu/binbash/command/DeleteCommandTest.java
@@ -1,11 +1,10 @@
 package seedu.binbash.command;
 
 import org.junit.jupiter.api.Test;
-import seedu.binbash.item.Item;
+
 import seedu.binbash.ItemList;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/src/test/java/seedu/binbash/command/DeleteCommandTest.java
+++ b/src/test/java/seedu/binbash/command/DeleteCommandTest.java
@@ -13,7 +13,7 @@ class DeleteCommandTest {
 
     @Test
     void execute_deleteCommandOnListWithTestItem_success() {
-        ItemList itemList = new ItemList(new ArrayList<Item>());
+        ItemList itemList = new ItemList();
         itemList.addItem("retail", "testItem", "A test item", 1,
                 LocalDate.now(), 10.00, 5.00);
 

--- a/src/test/java/seedu/binbash/command/ListCommandTest.java
+++ b/src/test/java/seedu/binbash/command/ListCommandTest.java
@@ -13,7 +13,7 @@ class ListCommandTest {
 
     @Test
     void execute_listCommandWithTwoItemsInItemList_correctPrintFormatForBothItems() {
-        ItemList itemList = new ItemList(new ArrayList<Item>());
+        ItemList itemList = new ItemList();
 
         itemList.addItem("retail", "testItem1", "Test item 1", 2,
                 LocalDate.of(1999, 1, 1), 4.00, 5.00);
@@ -45,7 +45,7 @@ class ListCommandTest {
 
     @Test
     void execute_listCommandWithEmptyItemList_returnsEmptyOutput() {
-        ItemList itemList = new ItemList(new ArrayList<Item>());
+        ItemList itemList = new ItemList();
         ListCommand listCommand = new ListCommand();
 
         listCommand.execute(itemList);

--- a/src/test/java/seedu/binbash/command/ListCommandTest.java
+++ b/src/test/java/seedu/binbash/command/ListCommandTest.java
@@ -1,11 +1,10 @@
 package seedu.binbash.command;
 
 import org.junit.jupiter.api.Test;
-import seedu.binbash.item.Item;
+
 import seedu.binbash.ItemList;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/src/test/java/seedu/binbash/command/SearchCommandTest.java
+++ b/src/test/java/seedu/binbash/command/SearchCommandTest.java
@@ -15,28 +15,27 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 
 public class SearchCommandTest {
-    private final ArrayList<Item> testItemList = new ArrayList<>();
+    private ItemList testItemList = new ItemList();
 
     @BeforeEach
     public void setUp() {
-        testItemList.add(new OperationalItem("light bulb", "a light bulb used in the warehouse",
+        testItemList.getItemList().add(new OperationalItem("light bulb", "a light bulb used in the warehouse",
                     100, 0.20));
-        testItemList.add(new PerishableOperationalItem("battery", "a battery for in-store use", 500,
+        testItemList.getItemList().add(new PerishableOperationalItem("battery", "a battery for in-store use", 500,
                     LocalDate.of(2024, 1, 16), 0.10));
-        testItemList.add(new RetailItem("black pen", "zebra sarasa black 0.5", 50, 1.00, 0.70));
-        testItemList.add(new PerishableRetailItem("banana", "cavendish banana", 30,
+        testItemList.getItemList().add(new RetailItem("black pen", "zebra sarasa black 0.5", 50, 1.00, 0.70));
+        testItemList.getItemList().add(new PerishableRetailItem("banana", "cavendish banana", 30,
                     LocalDate.of(2024, 1, 4), 0.50, 0.40));
-        testItemList.add(new PerishableRetailItem("milk", "meiji full fat whole milk", 10,
+        testItemList.getItemList().add(new PerishableRetailItem("milk", "meiji full fat whole milk", 10,
                     LocalDate.of(2024, 2, 3), 5, 3.50));
     }
 
     @Test
     void execute_searchForMilk_found() {
-        ItemList itemList = new ItemList(testItemList);
         SearchCommand searchCommand = new SearchCommand();
         searchCommand.setNameField("milk");
 
-        searchCommand.execute(itemList);
+        searchCommand.execute(testItemList);
         ArrayList<Item> foundItems = searchCommand.getFoundItems();
         String foundItem = foundItems.get(0).getItemName();
         Assertions.assertTrue(foundItem.equals("milk") && foundItems.size() == 1);
@@ -44,11 +43,10 @@ public class SearchCommandTest {
 
     @Test
     void execute_searchForExpiry_foundBanana() {
-        ItemList itemList = new ItemList(testItemList);
         SearchCommand searchCommand = new SearchCommand();
         searchCommand.setExpiryDateField(LocalDate.of(2024, 2, 4));
 
-        searchCommand.execute(itemList);
+        searchCommand.execute(testItemList);
         ArrayList<Item> foundItems = searchCommand.getFoundItems();
         String foundItem = foundItems.get(0).getItemName();
         Assertions.assertTrue(foundItem.equals("banana") && foundItems.size() == 1);

--- a/src/test/java/seedu/binbash/parser/ParserTest.java
+++ b/src/test/java/seedu/binbash/parser/ParserTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 
 import seedu.binbash.ItemList;
 import seedu.binbash.command.AddCommand;

--- a/src/test/java/seedu/binbash/parser/ParserTest.java
+++ b/src/test/java/seedu/binbash/parser/ParserTest.java
@@ -26,7 +26,7 @@ public class ParserTest {
 
     @BeforeEach
     public void setUp() {
-        itemList = new ItemList(new ArrayList<>());
+        itemList = new ItemList();
         parser = new Parser();
     }
 


### PR DESCRIPTION
The new Parsing format (add -n -d -q etc.) is now used as the format for each item stored in the items.txt file. This is so that we can  utilize already existing methods such as AddCommand.execute() when loading up data.

As a result of this, the `ItemList` constructor will no longer take in any arguments. In main, an `ItemList` object will be initialized first, followed by a `Storage` object. After which, `Storage.loadData(itemList)` will be called, taking in an ItemList argument. The loadData method will then populate the Array List within `itemList`.

Below is a sample items.txt file that you may use. It contains the 4 types of items that we have: _Retail_, _PerishableRetail_, _Operational_, and _PerishableOperational_.
____________________________________________________________________
add -n Shovel -d Metal -q 50 -c 2.0 -s 10.0 -re 
setprofit 100 50
add -n Fertilizer -d NPK -q 100 -c 5.0 -s 10.0 -re -e 12-12-2024 
setprofit 100 50
add -n Moisture Meter -d Green -q 20 -c 5.0 -op 
setprofit 25 
add -n Water -d Dechlorinated -q 150 -c 2.0 -op -e 12-12-2024 
setprofit 150 

_____________________________________________________________________
Future Improvements: The UpdateCommand method (once it is out!), can be used in the future to replace the "setprofit" line we are currently using. Each item can now be represented as 

eg.
add -n Shovel -d Metal -q 50 -c 2.0 -s 10.0 -re 
update -x 100 -y 50 

(assuming -x is the flag for totalQuantityPurchased and -y is the flag for totalQuantitySold)


Towards #129 