### PR TITLE
Refactor storage format and improve defensiveness of storage class

### DIFF
--- a/src/main/java/seedu/binbash/BinBash.java
+++ b/src/main/java/seedu/binbash/BinBash.java
@@ -20,15 +20,14 @@ public class BinBash {
     public BinBash() {
         logger = new BinBashLogger(BinBash.class.getName());
         userInterface = new Ui();
-        itemList = new ItemList();
         storage = new Storage();
+        itemList = new ItemList(storage.loadData());
         inputParser = new Parser();
     }
 
     private void run() {
         logger.info("BinBash starting...");
 
-        storage.loadData(itemList);
         userInterface.greet();
         userInterface.talk(itemList.getProfitMargin());
 

--- a/src/main/java/seedu/binbash/command/ByeCommand.java
+++ b/src/main/java/seedu/binbash/command/ByeCommand.java
@@ -12,6 +12,7 @@ public class ByeCommand extends Command {
     @Override
     public boolean execute(ItemList itemList) {
         executionUiOutput = "Bye!";
+        hasToSave = true;
         return true;
     }
 }

--- a/src/main/java/seedu/binbash/inventory/ItemList.java
+++ b/src/main/java/seedu/binbash/inventory/ItemList.java
@@ -19,8 +19,8 @@ public class ItemList {
     private final ArrayList<Item> itemList;
     private SearchAssistant searchAssistant;
 
-    public ItemList() {
-        this.itemList = new ArrayList<Item>();
+    public ItemList(ArrayList<Item> itemList) {
+        this.itemList = itemList;
         this.totalRevenue = 0;
         this.totalCost = 0;
         searchAssistant = new SearchAssistant();

--- a/src/main/java/seedu/binbash/logger/BinBashLogger.java
+++ b/src/main/java/seedu/binbash/logger/BinBashLogger.java
@@ -108,6 +108,10 @@ public class BinBashLogger {
         }
     }
 
+    public void consoleLog(String message) {
+        consoleLogger.log(Level.INFO, message);
+    }
+
     /**
      * Creates a file handler that allows log messages be written to the log file.
      */

--- a/src/main/java/seedu/binbash/storage/Storage.java
+++ b/src/main/java/seedu/binbash/storage/Storage.java
@@ -1,9 +1,5 @@
 package seedu.binbash.storage;
 
-import org.apache.commons.cli.ParseException;
-import seedu.binbash.inventory.ItemList;
-import seedu.binbash.command.Command;
-import seedu.binbash.exceptions.InvalidCommandException;
 import seedu.binbash.item.Item;
 import seedu.binbash.exceptions.BinBashException;
 import seedu.binbash.item.OperationalItem;
@@ -11,22 +7,37 @@ import seedu.binbash.item.PerishableRetailItem;
 import seedu.binbash.item.RetailItem;
 import seedu.binbash.logger.BinBashLogger;
 import seedu.binbash.item.PerishableOperationalItem;
-import seedu.binbash.parser.AddCommandParser;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.util.Arrays;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Manages storage operations for BinBash, including loading and saving item data.
+ */
 public class Storage {
-    private static final int READING_IN_PROFIT_QUANTITIES = 1;
-    private static final int READING_IN_ITEM = 0;
-    private static final int TOTAL_UNITS_PURCHASED_INDEX = 0;
-    private static final int TOTAL_UNITS_SOLD_INDEX = 1;
+
+    protected static final DateTimeFormatter EXPECTED_INPUT_DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+
+    private static final int ITEM_TYPE_INDEX = 0;
+    private static final int ITEM_NAME_INDEX = 1;
+    private static final int ITEM_DESCRIPTION_INDEX = 2;
+    private static final int ITEM_QUANTITY_INDEX = 3;
+    private static final int ITEM_COST_PRICE_INDEX = 4;
+    private static final int ITEM_TOTAL_UNITS_PURCHASED_INDEX = 5;
+    private static final int ITEM_EXPIRATION_DATE_INDEX = 6;
+    private static final int ITEM_SALE_PRICE_INDEX = 7;
+    private static final int ITEM_TOTAL_UNITS_SOLD_INDEX = 8;
+    private static final int ITEM_THRESHOLD_INDEX = 9;
+
+    private static final String DELIMITER = "|";
 
     protected String filePath;
     protected String dataDirectoryPath;
@@ -38,42 +49,101 @@ public class Storage {
         this.filePath = "data/items.txt";
         this.dataDirectoryPath = "./data/";
         this.dataFileName = "items.txt";
-        this.isCorrupted = false; // set to false by default}
+        this.isCorrupted = false; // set to false by default
         this.storageLogger = new BinBashLogger(Storage.class.getName());
     }
 
-    // TODO: Handle exceptions properly (when the exceptions for AddCommand are settled)
-    //  Lumping 3 exceptions together without a custom message for each
-    //  exception is bad exception handling!
-
     /**
-     * Loads the data from the file into the itemManager.
-     * If the data file is corrupted or an error occurs during reading, the file is marked as corrupted.
+     * Loads item data from the storage file and returns a list of items.
+     * If the file is corrupted, it will attempt to handle the corrupted file
+     * by renaming it and creating a new file.
      *
-     * @param itemManager The ItemList object to add loaded items to.
-     * @throws RuntimeException if an error occurs during file reading.
+     * @return A list of items loaded from the storage file. Returns an empty list if the file is corrupted.
      */
-    public void loadData(ItemList itemManager) {
+    public ArrayList<Item> loadData() {
         storageLogger.info("Preparing to load data from storage file.");
+        ArrayList<Item> outputList = new ArrayList<>();
 
         try {
             ArrayList<String> stringRepresentationOfTxtFile = readTxtFile();
-            parseAndAddToList(stringRepresentationOfTxtFile, itemManager);
-        } catch (BinBashException | IOException | NumberFormatException e) {
-            isCorrupted = true;
+            outputList = parseLinesToItemList(stringRepresentationOfTxtFile);
+        } catch (BinBashException | IOException e) {
+            storageLogger.severe("Error creating the data directory and/or file.");
         }
 
-        if (isCorrupted) {
-            storageLogger.warning("Data file is corrupted. A new data file will be generated. "
-                    + "Proceed at your own risk");
+        if (!isCorrupted) {
+            storageLogger.consoleLog("Data loaded successfully");
+            return outputList;
         } else {
-            storageLogger.info("Data loaded successfully.");
+            handleCorruptedFile();
+            storageLogger.consoleLog("User will be given an empty inventory.");
+            return new ArrayList<Item>();
         }
     }
 
     /**
-     * Reads the data file ('items.txt') and returns a list of strings representing each line in the file.
-     * If the 'data' directory or 'items.txt' file does not exist, they will be created.
+     * Handles a corrupted data file by renaming the corrupted file and creating a new data file.
+     * If both operations are successful, it logs the success message. Otherwise, it logs a warning message.
+     */
+    private void handleCorruptedFile() {
+        storageLogger.consoleLog("Data file is corrupted. BinBash is attempting to rename the corrupted file" +
+                "and create a new data file.");
+
+        boolean isRenamed = isCorruptedFileRenamed();
+        boolean isNewFileCreated = isNewFileCreated();
+
+        if (isRenamed && isNewFileCreated) {
+            storageLogger.consoleLog("Corrupted file renamed and new items.txt file created. Old corrupted file is " +
+                            "within the ./data/ directory.");
+        } else {
+            storageLogger.consoleLog("Failed to rename the corrupted file or create a new items.txt file.");
+        }
+
+        assert isRenamed : "Failed to rename the corrupted file";
+        assert isNewFileCreated : "Failed to create a new items.txt file";
+    }
+
+    /**
+     * Renames the corrupted data file to "items_corrupted.txt".
+     *
+     * @return true if the file is successfully renamed, false otherwise.
+     */
+    private boolean isCorruptedFileRenamed() {
+        File corruptedFile = new File(filePath);
+        File renamedFile = new File(dataDirectoryPath + "items_corrupted.txt");
+
+        boolean isRenamed = corruptedFile.renameTo(renamedFile);
+
+        if (isRenamed) {
+            storageLogger.info("Corrupted file successfully renamed to items_corrupted.txt.");
+        }
+
+        return isRenamed;
+    }
+
+    /**
+     * Creates a new data file named "items.txt".
+     *
+     * @return true if the file is successfully created, false otherwise.
+     */
+    private boolean isNewFileCreated() {
+        File newFile = new File(filePath);
+
+        try {
+            if (newFile.createNewFile()) {
+                storageLogger.info("New items.txt file created successfully.");
+                return true;
+            }
+        } catch (IOException e) {
+            // This feels like a "proceed at your own risk" kind of statement.
+            storageLogger.severe("Error creating new items.txt file: " + e.getMessage());
+        }
+        return false;
+    }
+
+    /**
+     * Reads the data file ("items.txt") and returns a list of strings representing each line in the file.
+     * If the "data" directory or "items.txt" file does not exist, they will be created.
      *
      * @return A list of strings, each representing a line in the data file.
      * @throws BinBashException if the directory or file cannot be created.
@@ -108,77 +178,96 @@ public class Storage {
     }
 
     /**
-     * Parses the string representation of the text file and adds items to the list of items.
-     * The method handles both "add" command and "setprofit" strings to populate the item list.
+     * Parses the string representation of a text file and returns a list of items.
      *
      * @param stringRepresentationOfTxtFile The list of strings representing each line in the text file.
-     * @param itemManager The ItemList object containing the empty list of items.
+     * @return A list of items parsed from the text file.
      */
-    private void parseAndAddToList(ArrayList<String> stringRepresentationOfTxtFile, ItemList itemManager) {
-
-        AddCommandParser addCommandParser = new AddCommandParser();
-        int parseState = READING_IN_ITEM;
+    private ArrayList<Item> parseLinesToItemList(ArrayList<String> stringRepresentationOfTxtFile) {
+        ArrayList<Item> outputList = new ArrayList<>();
 
         for (String line : stringRepresentationOfTxtFile) {
-            String[] tokens = line.trim().split("\\s+");
-            String commandString = tokens[0].toLowerCase();
-            String[] commandArgs = Arrays.copyOfRange(tokens, 1, tokens.length);
-
-            switch (commandString) {
-            case "add":
-                assert parseState == READING_IN_ITEM;
-                try {
-                    handleAddCommand(addCommandParser, commandArgs, itemManager);
-                } catch (InvalidCommandException | ParseException e) {
+            try {
+                Item item = convertLineToItem(line);
+                if (item != null) {
+                    outputList.add(item);
+                } else {
                     isCorrupted = true;
                 }
-                parseState = READING_IN_PROFIT_QUANTITIES;
-                break;
-            case "setprofit":
-                assert parseState == READING_IN_PROFIT_QUANTITIES;
-                handleSetProfitString(commandArgs, itemManager);
-                parseState = READING_IN_ITEM;
-                break;
-            default:
+            } catch (NumberFormatException | DateTimeParseException e) {
                 isCorrupted = true;
             }
         }
+        return outputList;
     }
 
     /**
-     * Handles the "add" command by parsing the arguments and executing the command to add an item to the item list.
+     * Parses a single line from the text file to create an item object.
      *
-     * @param addCommandParser The parser object used to parse the add command.
-     * @param commandArgs The arguments of the add command.
-     * @param itemManager The ItemList object to which the new item is added.
-     * @throws InvalidCommandException if the command is invalid.
-     * @throws ParseException if there is an error in parsing the command arguments.
+     * @param line The string representation of a single line in the text file.
+     * @return The item object created from the line, or {@code null} if the item type is unknown.
      */
-    private void handleAddCommand(AddCommandParser addCommandParser, String[] commandArgs, ItemList itemManager)
-            throws InvalidCommandException, ParseException {
-        Command addCommand = addCommandParser.parse(commandArgs);
-        addCommand.execute(itemManager);
-    }
+    private Item convertLineToItem(String line) {
+        String[] itemElements = line.split("\\|");
+        String itemType = itemElements[ITEM_TYPE_INDEX];
 
-    /**
-     * Handles the "setprofit" string by updating the profit-related properties of the most recently added item.
-     *
-     * @param commandArgs The arguments of the setprofit command.
-     * @param itemManager The ItemList object containing the recently added item.
-     */
-    private void handleSetProfitString(String[] commandArgs, ItemList itemManager) {
-        List<Item> itemList = itemManager.getItemList();
-        Item recentlyAddedItem = itemList.get(itemList.size() - 1);
+        switch (itemType) {
+        case "OperationalItem":
 
-        String totalUnitsPurchased = commandArgs[TOTAL_UNITS_PURCHASED_INDEX];
-        recentlyAddedItem.setTotalUnitsPurchased(Integer.parseInt(totalUnitsPurchased));
+            OperationalItem operationalItem = new OperationalItem(
+                    itemElements[ITEM_NAME_INDEX],
+                    itemElements[ITEM_DESCRIPTION_INDEX],
+                    Integer.parseInt(itemElements[ITEM_QUANTITY_INDEX]),
+                    Double.parseDouble(itemElements[ITEM_COST_PRICE_INDEX])
+            );
+            operationalItem.setTotalUnitsPurchased(Integer.parseInt(itemElements[ITEM_TOTAL_UNITS_PURCHASED_INDEX]));
 
-        if (recentlyAddedItem instanceof RetailItem) {
-            String totalUnitsSold = commandArgs[TOTAL_UNITS_SOLD_INDEX];
-            ((RetailItem) recentlyAddedItem).setTotalUnitsSold(Integer.parseInt(totalUnitsSold));
+            return operationalItem;
+        case "PerishableOperationalItem":
+
+            PerishableOperationalItem perishableOperationalItem = new PerishableOperationalItem(
+                    itemElements[ITEM_NAME_INDEX],
+                    itemElements[ITEM_DESCRIPTION_INDEX],
+                    Integer.parseInt(itemElements[ITEM_QUANTITY_INDEX]),
+                    LocalDate.parse(itemElements[ITEM_EXPIRATION_DATE_INDEX], EXPECTED_INPUT_DATE_FORMAT),
+                    Double.parseDouble(itemElements[ITEM_COST_PRICE_INDEX])
+            );
+            perishableOperationalItem.setTotalUnitsPurchased(Integer.parseInt(
+                    itemElements[ITEM_TOTAL_UNITS_PURCHASED_INDEX]));
+
+            return perishableOperationalItem;
+        case "PerishableRetailItem":
+
+            PerishableRetailItem perishableRetailItem = new PerishableRetailItem(
+                    itemElements[ITEM_NAME_INDEX],
+                    itemElements[ITEM_DESCRIPTION_INDEX],
+                    Integer.parseInt(itemElements[ITEM_QUANTITY_INDEX]),
+                    LocalDate.parse(itemElements[ITEM_EXPIRATION_DATE_INDEX], EXPECTED_INPUT_DATE_FORMAT),
+                    Double.parseDouble(itemElements[ITEM_SALE_PRICE_INDEX]),
+                    Double.parseDouble(itemElements[ITEM_COST_PRICE_INDEX])
+            );
+            perishableRetailItem.setTotalUnitsPurchased(Integer.parseInt(
+                    itemElements[ITEM_TOTAL_UNITS_PURCHASED_INDEX]));
+            perishableRetailItem.setTotalUnitsSold(Integer.parseInt(
+                    itemElements[ITEM_TOTAL_UNITS_SOLD_INDEX]));
+
+            return perishableRetailItem;
+        case "RetailItem":
+            RetailItem retailItem = new RetailItem(
+                    itemElements[ITEM_NAME_INDEX],
+                    itemElements[ITEM_DESCRIPTION_INDEX],
+                    Integer.parseInt(itemElements[ITEM_QUANTITY_INDEX]),
+                    Double.parseDouble(itemElements[ITEM_SALE_PRICE_INDEX]),
+                    Double.parseDouble(itemElements[ITEM_COST_PRICE_INDEX])
+            );
+            retailItem.setTotalUnitsPurchased(Integer.parseInt(itemElements[ITEM_TOTAL_UNITS_PURCHASED_INDEX]));
+            retailItem.setTotalUnitsSold(Integer.parseInt(itemElements[ITEM_TOTAL_UNITS_SOLD_INDEX]));
+
+            return retailItem;
+        default:
+            return null;
         }
     }
-
 
     /**
      * Saves the list of items to the storage file in a format suitable for loading.
@@ -199,12 +288,11 @@ public class Storage {
 
     /**
      * Generates a string representation of the list of items to be saved to the file.
-     * Each item is represented in the format of an "add" command followed by a "setprofit" string.
      *
      * @param itemList The list of items to be converted into a string.
      * @return A string representation of the list of items, suitable for saving to a file.
      */
-    private static String generateTextToSave(List<Item> itemList) {
+    private String generateTextToSave(List<Item> itemList) {
         String textToSave = "";
 
         for (Item item: itemList) {
@@ -217,49 +305,57 @@ public class Storage {
     }
 
     /**
-     * Generates a string representation of a single item in the format of an "add" command, followed by
-     * a "setprofit" string
+     * Generates a string representation of a single item.
      *
      * @param item The item to be converted into a string.
      * @return A string representation of the item, suitable for saving to a file.
      */
-    private static String generateStorageRepresentationOfSingleItem(Item item) {
-        String output = "";
+    private String generateStorageRepresentationOfSingleItem(Item item) {
+        String itemType = item.getClass().getSimpleName();
 
-        output += "add "
-                + "-n " + item.getItemName() + " "
-                + "-d " + item.getItemDescription() + " "
-                + "-q " + item.getItemQuantity() + " "
-                + "-c " + item.getItemCostPrice() + " ";
+        // Common fields for all item types
+        String output = itemType + DELIMITER
+                + item.getItemName() + DELIMITER
+                + item.getItemDescription() + DELIMITER
+                + item.getItemQuantity() + DELIMITER
+                + item.getItemCostPrice() + DELIMITER
+                + item.getTotalUnitsPurchased() + DELIMITER;
 
-        if (item instanceof RetailItem) {
-            RetailItem retailItem = (RetailItem) item;
-            output += "-s " + retailItem.getItemSalePrice() + " "
-                    + "-re ";
-        }
-
-        if (item instanceof PerishableRetailItem) {
-            PerishableRetailItem perishableRetailItem = (PerishableRetailItem) item;
-            output += "-e " + perishableRetailItem.getItemExpirationDate() + " ";
-        }
-
-        if (item instanceof OperationalItem) {
-            output += "-op ";
-        }
-
-        if (item instanceof PerishableOperationalItem) {
+        // Additional fields for specific item types
+        switch (itemType) {
+        case "OperationalItem":
+            output += " " + DELIMITER
+                    + " " + DELIMITER
+                    + " " + DELIMITER
+                    + " " + DELIMITER;
+            break;
+        case "PerishableOperationalItem":
             PerishableOperationalItem perishableOperationalItem = (PerishableOperationalItem) item;
-            output += "-e " + perishableOperationalItem.getItemExpirationDate() + " ";
-        }
 
-        output += System.lineSeparator();
+            output += perishableOperationalItem.getItemExpirationDate() + DELIMITER
+                    + " " + DELIMITER
+                    + " " + DELIMITER
+                    + " " + DELIMITER;
+            break;
+        case "PerishableRetailItem":
+            PerishableRetailItem perishableRetailItem = (PerishableRetailItem) item;
 
-        output += "setprofit "
-                + item.getTotalUnitsPurchased() + " ";
-
-        if (item instanceof RetailItem) {
+            output += perishableRetailItem.getItemExpirationDate() + DELIMITER
+                    + perishableRetailItem.getItemSalePrice() + DELIMITER
+                    + perishableRetailItem.getTotalUnitsSold() + DELIMITER
+                    + " " + DELIMITER;
+            break;
+        case "RetailItem":
             RetailItem retailItem = (RetailItem) item;
-            output += retailItem.getTotalUnitsSold();
+
+            output += " " + DELIMITER
+                    + retailItem.getItemSalePrice() + DELIMITER
+                    + retailItem.getTotalUnitsSold() + DELIMITER
+                    + " " + DELIMITER;
+            break;
+        default:
+            isCorrupted = true;
+            break;
         }
 
         return output;

--- a/src/main/java/seedu/binbash/storage/Storage.java
+++ b/src/main/java/seedu/binbash/storage/Storage.java
@@ -73,12 +73,11 @@ public class Storage {
 
         if (!isCorrupted) {
             storageLogger.consoleLog("Data loaded successfully");
-            return outputList;
         } else {
             handleCorruptedFile();
-            storageLogger.consoleLog("User will be given an empty inventory.");
-            return new ArrayList<Item>();
+            storageLogger.consoleLog("User will be given an incomplete inventory.");
         }
+        return outputList;
     }
 
     /**
@@ -87,7 +86,7 @@ public class Storage {
      */
     private void handleCorruptedFile() {
         storageLogger.consoleLog("Data file is corrupted. BinBash is attempting to rename the corrupted file" +
-                "and create a new data file.");
+                " and create a new data file.");
 
         boolean isRenamed = isCorruptedFileRenamed();
         boolean isNewFileCreated = isNewFileCreated();

--- a/src/main/java/seedu/binbash/storage/Storage.java
+++ b/src/main/java/seedu/binbash/storage/Storage.java
@@ -148,7 +148,7 @@ public class Storage {
      * @throws BinBashException if the directory or file cannot be created.
      * @throws IOException if an error occurs during file reading.
      */
-    private ArrayList<String> readTxtFile() throws BinBashException, IOException {
+    protected ArrayList<String> readTxtFile() throws BinBashException, IOException {
         File dataDirectory = new File(dataDirectoryPath);
         File dataFile = new File(dataDirectory, dataFileName);
 
@@ -182,7 +182,7 @@ public class Storage {
      * @param stringRepresentationOfTxtFile The list of strings representing each line in the text file.
      * @return A list of items parsed from the text file.
      */
-    private ArrayList<Item> parseLinesToItemList(ArrayList<String> stringRepresentationOfTxtFile) {
+    protected ArrayList<Item> parseLinesToItemList(ArrayList<String> stringRepresentationOfTxtFile) {
         ArrayList<Item> outputList = new ArrayList<>();
 
         for (String line : stringRepresentationOfTxtFile) {
@@ -206,7 +206,7 @@ public class Storage {
      * @param line The string representation of a single line in the text file.
      * @return The item object created from the line, or {@code null} if the item type is unknown.
      */
-    private Item convertLineToItem(String line) {
+    protected Item convertLineToItem(String line) {
         String[] itemElements = line.split("\\|");
         String itemType = itemElements[ITEM_TYPE_INDEX];
 
@@ -295,7 +295,7 @@ public class Storage {
      * @param itemList The list of items to be converted into a string.
      * @return A string representation of the list of items, suitable for saving to a file.
      */
-    private String generateTextToSave(List<Item> itemList) {
+    protected String generateTextToSave(List<Item> itemList) {
         String textToSave = "";
 
         for (Item item: itemList) {
@@ -313,7 +313,7 @@ public class Storage {
      * @param item The item to be converted into a string.
      * @return A string representation of the item, suitable for saving to a file.
      */
-    private String generateStorageRepresentationOfSingleItem(Item item) {
+    protected String generateStorageRepresentationOfSingleItem(Item item) {
         String itemType = item.getClass().getSimpleName();
 
         // Common fields for all item types

--- a/src/test/java/seedu/binbash/ItemListTest.java
+++ b/src/test/java/seedu/binbash/ItemListTest.java
@@ -3,11 +3,13 @@ package seedu.binbash;
 import org.junit.jupiter.api.Test;
 
 import seedu.binbash.inventory.ItemList;
+import seedu.binbash.item.Item;
 import seedu.binbash.item.OperationalItem;
 import seedu.binbash.item.PerishableOperationalItem;
 import seedu.binbash.item.PerishableRetailItem;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -16,7 +18,7 @@ class ItemListTest {
 
     @Test
     void deleteItem_indexOfItemInItemList_itemRemovedFromItemList() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00, 6);
 
@@ -27,7 +29,7 @@ class ItemListTest {
 
     @Test
     void deleteItem_nameOfItemInItemList_itemRemovedFromItemList() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00,6);
 
@@ -38,7 +40,7 @@ class ItemListTest {
 
     @Test
     void deleteItem_nameOfItemNotInItemList_itemNotRemovedFromItemList() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00, 6);
 
@@ -49,7 +51,7 @@ class ItemListTest {
 
     @Test
     void addItem_noItemInItemList_oneItemInItemList() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
 
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00, 6);
@@ -58,7 +60,7 @@ class ItemListTest {
 
     @Test
     void addItem_itemInputs_correctItemParameters() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
 
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.of(1999, 1, 1), 4.00, 5.00, 6);
@@ -74,7 +76,7 @@ class ItemListTest {
 
     @Test
     void addItem_addOperationalItem_correctItemType() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
 
         itemList.addItem("operational", "testItem", "A test item", 2,
                 LocalDate.MIN, 0.00, 5.00, 6);
@@ -83,7 +85,7 @@ class ItemListTest {
 
     @Test
     void addItem_addPerishableOperationalItem_correctItemType() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
 
         itemList.addItem("operational", "testItem", "A test item", 2,
                 LocalDate.of(1999, 1, 1), 0.00, 5.00, 6);
@@ -92,7 +94,7 @@ class ItemListTest {
 
     @Test
     void printList_twoItemsInItemList_correctPrintFormatForBothItems() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
 
         itemList.addItem("retail", "testItem1", "Test item 1", 2,
                 LocalDate.of(1999, 1, 1), 4.00, 5.00, 6);

--- a/src/test/java/seedu/binbash/command/AddCommandTest.java
+++ b/src/test/java/seedu/binbash/command/AddCommandTest.java
@@ -2,10 +2,12 @@ package seedu.binbash.command;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.binbash.item.Item;
 import seedu.binbash.item.PerishableRetailItem;
 import seedu.binbash.inventory.ItemList;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -13,7 +15,7 @@ public class AddCommandTest {
 
     @Test
     void execute_item_oneItemInItemList() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         AddCommand addCommand = new AddCommand("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00, 6);
 
@@ -23,7 +25,7 @@ public class AddCommandTest {
 
     @Test
     void execute_multipleItems_multipleItemsInItemList() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         AddCommand addCommand1 = new AddCommand("retail", "item1", "First item", 10,
                 LocalDate.now(), 1.00, 2.00, 5);
         AddCommand addCommand2 = new AddCommand("operational", "item2", "Second item", 20,
@@ -36,7 +38,7 @@ public class AddCommandTest {
 
     @Test
     void execute_itemDetails_correctItemDetails() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         AddCommand addCommand = new AddCommand("retail", "testItem", "A test item", 2,
                 LocalDate.of(1999, 1, 1), 4.00, 5.00, 6);
 

--- a/src/test/java/seedu/binbash/command/DeleteCommandTest.java
+++ b/src/test/java/seedu/binbash/command/DeleteCommandTest.java
@@ -3,8 +3,10 @@ package seedu.binbash.command;
 import org.junit.jupiter.api.Test;
 
 import seedu.binbash.inventory.ItemList;
+import seedu.binbash.item.Item;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -12,7 +14,7 @@ class DeleteCommandTest {
 
     @Test
     void execute_validItemIndex_itemRemovedFromItemList() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         itemList.addItem("retail", "test", "A test item", 2,
                 LocalDate.now(), 2.00, 1.00, 3);
 
@@ -24,7 +26,7 @@ class DeleteCommandTest {
 
     @Test
     void execute_validItemName_itemRemovedFromItemList() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         itemList.addItem("retail", "test", "A test item", 2,
                 LocalDate.now(), 2.00, 1.00, 3);
 
@@ -36,7 +38,7 @@ class DeleteCommandTest {
 
     @Test
     void execute_invalidItemIndex_itemNotRemovedFromItemList() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         itemList.addItem("retail", "test", "A test item", 2,
                 LocalDate.now(), 2.00, 1.00, 3);
 
@@ -48,7 +50,7 @@ class DeleteCommandTest {
 
     @Test
     void execute_invalidItemName_itemNotRemovedFromItemList() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         itemList.addItem("retail", "test", "A test item", 2,
                 LocalDate.now(), 2.00, 1.00, 3);
 

--- a/src/test/java/seedu/binbash/command/ListCommandTest.java
+++ b/src/test/java/seedu/binbash/command/ListCommandTest.java
@@ -3,8 +3,10 @@ package seedu.binbash.command;
 import org.junit.jupiter.api.Test;
 
 import seedu.binbash.inventory.ItemList;
+import seedu.binbash.item.Item;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -12,7 +14,7 @@ class ListCommandTest {
 
     @Test
     void execute_listCommandWithTwoItemsInItemList_correctPrintFormatForBothItems() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
 
         itemList.addItem("retail", "testItem1", "Test item 1", 2,
                 LocalDate.of(1999, 1, 1), 4.00, 5.00, 6);
@@ -46,7 +48,7 @@ class ListCommandTest {
 
     @Test
     void execute_listCommandWithEmptyItemList_returnsEmptyOutput() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         ListCommand listCommand = new ListCommand();
 
         listCommand.execute(itemList);

--- a/src/test/java/seedu/binbash/command/RestockCommandTest.java
+++ b/src/test/java/seedu/binbash/command/RestockCommandTest.java
@@ -6,6 +6,7 @@ import seedu.binbash.exceptions.InvalidArgumentException;
 import seedu.binbash.item.Item;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -14,7 +15,7 @@ public class RestockCommandTest {
 
     @Test
     void execute_restockExistingItem_quantityUpdated() throws InvalidArgumentException {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         String itemName = "testItem";
         itemList.addItem("retail", itemName, "A test item", 2,
                 LocalDate.now(), 4.00, 5.00, 6);
@@ -28,7 +29,7 @@ public class RestockCommandTest {
 
     @Test
     void execute_itemNotFound_noChangeInItemList() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         RestockCommand restockCommand = new RestockCommand("nonexistentItem", 5);
 
         assertTrue(restockCommand.execute(itemList));

--- a/src/test/java/seedu/binbash/command/SearchCommandTest.java
+++ b/src/test/java/seedu/binbash/command/SearchCommandTest.java
@@ -15,7 +15,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 
 public class SearchCommandTest {
-    private ItemList testItemList = new ItemList();
+    private ItemList testItemList = new ItemList(new ArrayList<Item>());
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/seedu/binbash/command/SellCommandTest.java
+++ b/src/test/java/seedu/binbash/command/SellCommandTest.java
@@ -6,6 +6,7 @@ import seedu.binbash.exceptions.InvalidArgumentException;
 import seedu.binbash.item.Item;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -14,7 +15,7 @@ public class SellCommandTest {
 
     @Test
     void execute_sellExistingItem_quantityUpdated() throws InvalidArgumentException {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         String itemName = "testItem";
         itemList.addItem("retail", itemName, "A test item", 9,
                 LocalDate.now(), 4.00, 5.00, 6);
@@ -28,7 +29,7 @@ public class SellCommandTest {
 
     @Test
     void execute_itemNotFound_noChangeInItemList() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         RestockCommand restockCommand = new RestockCommand("nonexistentItem", 5);
 
         assertTrue(restockCommand.execute(itemList));

--- a/src/test/java/seedu/binbash/command/UpdateCommandTest.java
+++ b/src/test/java/seedu/binbash/command/UpdateCommandTest.java
@@ -3,9 +3,11 @@ package seedu.binbash.command;
 import org.junit.jupiter.api.Test;
 import seedu.binbash.inventory.ItemList;
 import seedu.binbash.exceptions.InvalidArgumentException;
+import seedu.binbash.item.Item;
 import seedu.binbash.item.PerishableRetailItem;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -14,7 +16,7 @@ public class UpdateCommandTest {
 
     @Test
     void execute_updateByName_itemUpdated() throws InvalidArgumentException {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00, 6);
 
@@ -38,7 +40,7 @@ public class UpdateCommandTest {
 
     @Test
     void execute_updateByIndex_itemUpdated() throws InvalidArgumentException {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00, 6);
 
@@ -63,7 +65,7 @@ public class UpdateCommandTest {
 
     @Test
     void execute_itemNotFound_updateFailed() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         UpdateCommand updateCommand = new UpdateCommand("nonexistentItem");
         updateCommand.setItemDescription("Updated item");
         updateCommand.setItemQuantity(5);
@@ -78,7 +80,7 @@ public class UpdateCommandTest {
 
     @Test
     void execute_indexOutOfBounds_updateFailed() {
-        ItemList itemList = new ItemList();
+        ItemList itemList = new ItemList(new ArrayList<Item>());
         itemList.addItem("retail", "testItem", "A test item", 2,
                 LocalDate.now(), 4.00, 5.00, 6);
 

--- a/src/test/java/seedu/binbash/parser/ParserTest.java
+++ b/src/test/java/seedu/binbash/parser/ParserTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 
 import seedu.binbash.inventory.ItemList;
 import seedu.binbash.command.AddCommand;
@@ -15,6 +16,7 @@ import seedu.binbash.exceptions.BinBashException;
 import seedu.binbash.exceptions.InvalidCommandException;
 import seedu.binbash.exceptions.InvalidArgumentException;
 import seedu.binbash.exceptions.InvalidFormatException;
+import seedu.binbash.item.Item;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,7 +29,7 @@ public class ParserTest {
 
     @BeforeEach
     public void setUp() {
-        itemList = new ItemList();
+        itemList = new ItemList(new ArrayList<Item>());
         parser = new Parser();
     }
 

--- a/src/test/java/seedu/binbash/storage/StorageTest.java
+++ b/src/test/java/seedu/binbash/storage/StorageTest.java
@@ -1,6 +1,11 @@
 package seedu.binbash.storage;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import seedu.binbash.item.Item;

--- a/src/test/java/seedu/binbash/storage/StorageTest.java
+++ b/src/test/java/seedu/binbash/storage/StorageTest.java
@@ -3,7 +3,11 @@ package seedu.binbash.storage;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import seedu.binbash.item.*;
+import seedu.binbash.item.Item;
+import seedu.binbash.item.OperationalItem;
+import seedu.binbash.item.PerishableOperationalItem;
+import seedu.binbash.item.PerishableRetailItem;
+import seedu.binbash.item.RetailItem;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -18,7 +22,7 @@ class StorageTest {
     }
 
     @Test
-    public void generateStorageRepresentationOfSingleItem_OperationalItem_CorrectStringRepresentation() {
+    public void generateStorageRepresentationOfSingleItem_operationalItem_correctStringRepresentation() {
         OperationalItem operationalItem = new OperationalItem(
                 "item1",
                 "description1",
@@ -31,7 +35,7 @@ class StorageTest {
     }
 
     @Test
-    public void generateStorageRepresentationOfSingleItem_PerishableOperationalItem_CorrectStringRepresentation() {
+    public void generateStorageRepresentationOfSingleItem_perishableOperationalItem_correctStringRepresentation() {
         PerishableOperationalItem perishableOperationalItem = new PerishableOperationalItem(
                 "item2",
                 "description2",
@@ -45,7 +49,7 @@ class StorageTest {
     }
 
     @Test
-    public void generateStorageRepresentationOfSingleItem_PerishableRetailItem_CorrectStringRepresentation() {
+    public void generateStorageRepresentationOfSingleItem_perishableRetailItem_correctStringRepresentation() {
         PerishableRetailItem perishableRetailItem = new PerishableRetailItem(
                 "item3",
                 "description3",
@@ -61,7 +65,7 @@ class StorageTest {
     }
 
     @Test
-    public void generateStorageRepresentationOfSingleItem_RetailItem_CorrectStringRepresentation() {
+    public void generateStorageRepresentationOfSingleItem_retailItem_correctStringRepresentation() {
         RetailItem retailItem = new RetailItem(
                 "item4",
                 "description4",
@@ -76,7 +80,7 @@ class StorageTest {
     }
 
     @Test
-    void convertLineToItem_OperationalItemWithValidData_ExpectOperationalItem() {
+    void convertLineToItem_operationalItemWithValidData_expectOperationalItem() {
         String validOperationalItem =
                 "OperationalItem|Hammer|Heavy Duty Hammer|50|19.99|200|20|||";
         Item result = storage.convertLineToItem(validOperationalItem);
@@ -92,7 +96,7 @@ class StorageTest {
     }
 
     @Test
-    void convertLineToItem_PerishableOperationalItemWithValidData_ExpectPerishableOperationalItem() {
+    void convertLineToItem_perishableOperationalItemWithValidData_expectPerishableOperationalItem() {
         String validPerishableOperationalItem =
                 "PerishableOperationalItem|Paint|Blue Paint|100|35.50|500|10|31-12-2024|||";
         Item result = storage.convertLineToItem(validPerishableOperationalItem);
@@ -109,7 +113,7 @@ class StorageTest {
     }
 
     @Test
-    void convertLineToItem_PerishableRetailItemWithValidData_ExpectPerishableRetailItem() {
+    void convertLineToItem_perishableRetailItemWithValidData_expectPerishableRetailItem() {
         String validPerishableRetailItem =
                 "PerishableRetailItem|Milk|2L Whole Milk|200|1.99|200|50|31-12-2024|2.99|150|";
         Item result = storage.convertLineToItem(validPerishableRetailItem);
@@ -128,7 +132,7 @@ class StorageTest {
     }
 
     @Test
-    void convertLineToItem_RetailItemWithValidData_ExpectRetailItem() {
+    void convertLineToItem_retailItemWithValidData_expectRetailItem() {
         String validRetailItem =
                 "RetailItem|Book|Science Fiction Novel|10|5.99|100|5||6.99|80|";
         Item result = storage.convertLineToItem(validRetailItem);
@@ -146,7 +150,7 @@ class StorageTest {
     }
 
     @Test
-    void convertLineToItem_InvalidItemType_ExpectNull() {
+    void convertLineToItem_invalidItemType_expectNull() {
         String invalidType = "UnknownItem|Item|Description|10|1.99|100|5|||";
         Item result = storage.convertLineToItem(invalidType);
 
@@ -154,7 +158,7 @@ class StorageTest {
     }
 
     @Test
-    void parseLinesToItemList_InvalidNumberFormat_ExpectCorruptionFlag() {
+    void parseLinesToItemList_invalidNumberFormat_expectCorruptionFlag() {
         ArrayList<String> linesWithInvalidNumber = new ArrayList<>();
         linesWithInvalidNumber.add("OperationalItem|Hammer|Heavy Duty Hammer|notANumber|19.99|200|20|||");
 
@@ -165,7 +169,7 @@ class StorageTest {
     }
 
     @Test
-    void parseLinesToItemList_InvalidDateFormat_ExpectCorruptionFlag() {
+    void parseLinesToItemList_invalidDateFormat_expectCorruptionFlag() {
         ArrayList<String> linesWithInvalidDate = new ArrayList<>();
         linesWithInvalidDate.add("PerishableOperationalItem|Paint|Blue Paint|100|35.50|500|10|31/12/2024|||");
 
@@ -175,7 +179,8 @@ class StorageTest {
         assertTrue(parsedItems.isEmpty());
     }
 
-    void parseLinesToItemList_ValidInputData_ExpectItemsAdded() {
+    @Test
+    void parseLinesToItemList_validInputData_expectItemsAdded() {
         ArrayList<String> linesWithValidData = new ArrayList<>();
         linesWithValidData.add("OperationalItem|Hammer|Heavy Duty Hammer|50|19.99|200|20|||");
         linesWithValidData.add("PerishableOperationalItem|Paint|Blue Paint|100|35.50|500|10|31-12-2024|||");

--- a/src/test/java/seedu/binbash/storage/StorageTest.java
+++ b/src/test/java/seedu/binbash/storage/StorageTest.java
@@ -1,0 +1,197 @@
+package seedu.binbash.storage;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.binbash.item.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+class StorageTest {
+
+    private Storage storage;
+
+    @BeforeEach
+    public void setUp() {
+        storage = new Storage();
+    }
+
+    @Test
+    public void generateStorageRepresentationOfSingleItem_OperationalItem_CorrectStringRepresentation() {
+        OperationalItem operationalItem = new OperationalItem(
+                "item1",
+                "description1",
+                10,
+                5.0,
+                2);
+        operationalItem.setTotalUnitsPurchased(15);
+        String expected = "OperationalItem|item1|description1|10|5.0|15|2| | | |";
+        assertEquals(expected, storage.generateStorageRepresentationOfSingleItem(operationalItem));
+    }
+
+    @Test
+    public void generateStorageRepresentationOfSingleItem_PerishableOperationalItem_CorrectStringRepresentation() {
+        PerishableOperationalItem perishableOperationalItem = new PerishableOperationalItem(
+                "item2",
+                "description2",
+                20,
+                LocalDate.of(2024, 12, 31),
+                10.0,
+                5);
+        perishableOperationalItem.setTotalUnitsPurchased(25);
+        String expected = "PerishableOperationalItem|item2|description2|20|10.0|25|5|31-12-2024| | |";
+        assertEquals(expected, storage.generateStorageRepresentationOfSingleItem(perishableOperationalItem));
+    }
+
+    @Test
+    public void generateStorageRepresentationOfSingleItem_PerishableRetailItem_CorrectStringRepresentation() {
+        PerishableRetailItem perishableRetailItem = new PerishableRetailItem(
+                "item3",
+                "description3",
+                30,
+                LocalDate.of(2024, 11, 30),
+                15.0,
+                7.5,
+                10);
+        perishableRetailItem.setTotalUnitsPurchased(35);
+        perishableRetailItem.setTotalUnitsSold(40);
+        String expected = "PerishableRetailItem|item3|description3|30|7.5|35|10|30-11-2024|15.0|40|";
+        assertEquals(expected, storage.generateStorageRepresentationOfSingleItem(perishableRetailItem));
+    }
+
+    @Test
+    public void generateStorageRepresentationOfSingleItem_RetailItem_CorrectStringRepresentation() {
+        RetailItem retailItem = new RetailItem(
+                "item4",
+                "description4",
+                40,
+                20.0,
+                10.0,
+                15);
+        retailItem.setTotalUnitsPurchased(45);
+        retailItem.setTotalUnitsSold(50);
+        String expected = "RetailItem|item4|description4|40|10.0|45|15| |20.0|50|";
+        assertEquals(expected, storage.generateStorageRepresentationOfSingleItem(retailItem));
+    }
+
+    @Test
+    void convertLineToItem_OperationalItemWithValidData_ExpectOperationalItem() {
+        String validOperationalItem =
+                "OperationalItem|Hammer|Heavy Duty Hammer|50|19.99|200|20|||";
+        Item result = storage.convertLineToItem(validOperationalItem);
+
+        assertInstanceOf(OperationalItem.class, result);
+        OperationalItem operationalItem = (OperationalItem) result;
+        assertEquals("Hammer", operationalItem.getItemName());
+        assertEquals("Heavy Duty Hammer", operationalItem.getItemDescription());
+        assertEquals(50, operationalItem.getItemQuantity());
+        assertEquals(19.99, operationalItem.getItemCostPrice());
+        assertEquals(200, operationalItem.getTotalUnitsPurchased());
+        assertEquals(20, operationalItem.getItemThreshold());
+    }
+
+    @Test
+    void convertLineToItem_PerishableOperationalItemWithValidData_ExpectPerishableOperationalItem() {
+        String validPerishableOperationalItem =
+                "PerishableOperationalItem|Paint|Blue Paint|100|35.50|500|10|31-12-2024|||";
+        Item result = storage.convertLineToItem(validPerishableOperationalItem);
+
+        assertInstanceOf(PerishableOperationalItem.class, result);
+        PerishableOperationalItem perishableOperationalItem = (PerishableOperationalItem) result;
+        assertEquals("Paint", perishableOperationalItem.getItemName());
+        assertEquals("Blue Paint", perishableOperationalItem.getItemDescription());
+        assertEquals(100, perishableOperationalItem.getItemQuantity());
+        assertEquals(35.50, perishableOperationalItem.getItemCostPrice());
+        assertEquals(500, perishableOperationalItem.getTotalUnitsPurchased());
+        assertEquals(10, perishableOperationalItem.getItemThreshold());
+        assertEquals("31-12-2024", perishableOperationalItem.getItemExpirationDate());
+    }
+
+    @Test
+    void convertLineToItem_PerishableRetailItemWithValidData_ExpectPerishableRetailItem() {
+        String validPerishableRetailItem =
+                "PerishableRetailItem|Milk|2L Whole Milk|200|1.99|200|50|31-12-2024|2.99|150|";
+        Item result = storage.convertLineToItem(validPerishableRetailItem);
+
+        assertInstanceOf(PerishableRetailItem.class, result);
+        PerishableRetailItem perishableRetailItem = (PerishableRetailItem) result;
+        assertEquals("Milk", perishableRetailItem.getItemName());
+        assertEquals("2L Whole Milk", perishableRetailItem.getItemDescription());
+        assertEquals(200, perishableRetailItem.getItemQuantity());
+        assertEquals(1.99, perishableRetailItem.getItemCostPrice());
+        assertEquals(200, perishableRetailItem.getTotalUnitsPurchased());
+        assertEquals(50, perishableRetailItem.getItemThreshold());
+        assertEquals("31-12-2024", perishableRetailItem.getItemExpirationDate());
+        assertEquals(2.99, perishableRetailItem.getItemSalePrice());
+        assertEquals(150, perishableRetailItem.getTotalUnitsSold());
+    }
+
+    @Test
+    void convertLineToItem_RetailItemWithValidData_ExpectRetailItem() {
+        String validRetailItem =
+                "RetailItem|Book|Science Fiction Novel|10|5.99|100|5||6.99|80|";
+        Item result = storage.convertLineToItem(validRetailItem);
+
+        assertInstanceOf(RetailItem.class, result);
+        RetailItem retailItem = (RetailItem) result;
+        assertEquals("Book", retailItem.getItemName());
+        assertEquals("Science Fiction Novel", retailItem.getItemDescription());
+        assertEquals(10, retailItem.getItemQuantity());
+        assertEquals(5.99, retailItem.getItemCostPrice());
+        assertEquals(100, retailItem.getTotalUnitsPurchased());
+        assertEquals(5, retailItem.getItemThreshold());
+        assertEquals(6.99, retailItem.getItemSalePrice());
+        assertEquals(80, retailItem.getTotalUnitsSold());
+    }
+
+    @Test
+    void convertLineToItem_InvalidItemType_ExpectNull() {
+        String invalidType = "UnknownItem|Item|Description|10|1.99|100|5|||";
+        Item result = storage.convertLineToItem(invalidType);
+
+        assertNull(result);
+    }
+
+    @Test
+    void parseLinesToItemList_InvalidNumberFormat_ExpectCorruptionFlag() {
+        ArrayList<String> linesWithInvalidNumber = new ArrayList<>();
+        linesWithInvalidNumber.add("OperationalItem|Hammer|Heavy Duty Hammer|notANumber|19.99|200|20|||");
+
+        ArrayList<Item> parsedItems = storage.parseLinesToItemList(linesWithInvalidNumber);
+
+        assertTrue(storage.isCorrupted);
+        assertTrue(parsedItems.isEmpty());
+    }
+
+    @Test
+    void parseLinesToItemList_InvalidDateFormat_ExpectCorruptionFlag() {
+        ArrayList<String> linesWithInvalidDate = new ArrayList<>();
+        linesWithInvalidDate.add("PerishableOperationalItem|Paint|Blue Paint|100|35.50|500|10|31/12/2024|||");
+
+        ArrayList<Item> parsedItems = storage.parseLinesToItemList(linesWithInvalidDate);
+
+        assertTrue(storage.isCorrupted);
+        assertTrue(parsedItems.isEmpty());
+    }
+
+    void parseLinesToItemList_ValidInputData_ExpectItemsAdded() {
+        ArrayList<String> linesWithValidData = new ArrayList<>();
+        linesWithValidData.add("OperationalItem|Hammer|Heavy Duty Hammer|50|19.99|200|20|||");
+        linesWithValidData.add("PerishableOperationalItem|Paint|Blue Paint|100|35.50|500|10|31-12-2024|||");
+        linesWithValidData.add("PerishableRetailItem|Milk|2L Whole Milk|200|1.99|200|50|31-12-2024|2.99|150|");
+        linesWithValidData.add("RetailItem|Book|Science Fiction Novel|10|5.99|100|5||6.99|80|");
+
+        ArrayList<Item> parsedItems = storage.parseLinesToItemList(linesWithValidData);
+
+        assertFalse(storage.isCorrupted);
+        assertEquals(4, parsedItems.size());
+
+        // Further checks could be added here to verify that each item
+        // is of the correct type and has the expected properties, but this feels sufficient.
+        assertInstanceOf(OperationalItem.class, parsedItems.get(0));
+        assertInstanceOf(PerishableOperationalItem.class, parsedItems.get(1));
+        assertInstanceOf(PerishableRetailItem.class, parsedItems.get(2));
+        assertInstanceOf(RetailItem.class, parsedItems.get(3));
+    }
+}


### PR DESCRIPTION
This PR does not need to be merged first. It should be merged after #139 (by @imanamirshah )

Working towards 
- #141 
- #135 
- #136 

The items.txt file now uses the pipe delimiter to separate the data pertaining to an `Item` object. This reduces the need for the `Storage` class to be coupled with the `AddCommand` class.

Additionally, a new _items.txt_ file will be created, when the data file is deemed to be corrupted upon loading. The already existing _items.txt_ file will be renamed to _items_corrupted.txt_. The user will also receive an incomplete inventory upon startup, and this is made known through the use of console logging.