### PR TITLE
Refactor sell and restock command to utilize the sorted list, instead of item list

### DIFF
--- a/src/main/java/seedu/binbash/command/RestockCommand.java
+++ b/src/main/java/seedu/binbash/command/RestockCommand.java
@@ -4,6 +4,7 @@ import seedu.binbash.exceptions.InvalidArgumentException;
 import seedu.binbash.logger.BinBashLogger;
 import seedu.binbash.inventory.ItemList;
 
+import java.util.ArrayList;
 import java.util.regex.Pattern;
 
 /**
@@ -67,12 +68,13 @@ public class RestockCommand extends Command{
     @Override
     public boolean execute(ItemList itemList) {
         if (isIndex) {
-            if (index <= 0 || index > itemList.getItemCount()) {
+            ArrayList<Integer> itemListSortedOrder = itemList.getSortedOrder();
+            if (index <= 0 || index > itemListSortedOrder.size()) {
                 commandLogger.info("Index entered is out of bounds");
                 executionUiOutput = "Index entered is out of bounds!";
                 return true;
             }
-            assert index > 0 && index <= itemList.getItemCount();
+            assert index > 0 && index <= itemListSortedOrder.size();
             commandLogger.info("Restock identifier is detected as an index");
             try {
                 executionUiOutput = itemList.sellOrRestockItem(index, restockQuantity, COMMAND);

--- a/src/main/java/seedu/binbash/command/SellCommand.java
+++ b/src/main/java/seedu/binbash/command/SellCommand.java
@@ -4,6 +4,7 @@ import seedu.binbash.exceptions.InvalidArgumentException;
 import seedu.binbash.logger.BinBashLogger;
 import seedu.binbash.inventory.ItemList;
 
+import java.util.ArrayList;
 import java.util.regex.Pattern;
 
 /**
@@ -67,12 +68,13 @@ public class SellCommand extends Command{
     @Override
     public boolean execute(ItemList itemList) {
         if (isIndex) {
-            if (index <= 0 || index > itemList.getItemCount()) {
+            ArrayList<Integer> itemListSortedOrder = itemList.getSortedOrder();
+            if (index <= 0 || index > itemListSortedOrder.size()) {
                 commandLogger.info("Index entered is out of bounds");
                 executionUiOutput = "Index entered is out of bounds!";
                 return true;
             }
-            assert index > 0 && index <= itemList.getItemCount();
+            assert index > 0 && index <= itemListSortedOrder.size();
             commandLogger.info("Sell identifier is detected as an index");
             try {
                 executionUiOutput = itemList.sellOrRestockItem(index, sellQuantity, COMMAND);

--- a/src/main/java/seedu/binbash/inventory/ItemList.java
+++ b/src/main/java/seedu/binbash/inventory/ItemList.java
@@ -357,6 +357,8 @@ public class ItemList {
             int totalUnitsSold = retailItem.getTotalUnitsSold();
             retailItem.setTotalUnitsSold(totalUnitsSold + quantityToUpdateBy);
             break;
+        default:
+            throw new InvalidArgumentException("Invalid argument!");
         }
 
         String output = "Great! I have updated the quantity of the item for you:" + System.lineSeparator()

--- a/src/main/java/seedu/binbash/inventory/ItemList.java
+++ b/src/main/java/seedu/binbash/inventory/ItemList.java
@@ -1,5 +1,6 @@
 package seedu.binbash.inventory;
 
+import seedu.binbash.command.SellCommand;
 import seedu.binbash.comparators.ItemComparatorByCostPrice;
 import seedu.binbash.comparators.ItemComparatorByExpiryDate;
 import seedu.binbash.comparators.ItemComparatorByProfit;
@@ -302,7 +303,7 @@ public class ItemList {
     }
 
     /**
-     * Finds an Item in the ItemList by its name.
+     * Finds an item in the sorted item list by its name.
      *
      * @param itemName The name of the Item to be found.
      * @return The Item with the given name.
@@ -319,43 +320,48 @@ public class ItemList {
         throw new InvalidCommandException("Item with name '" + itemName + "' not found.");
     }
 
-    private String sellOrRestock(Item item, int itemQuantity, String command) throws InvalidArgumentException {
+    private String sellOrRestock(Item item, int quantityToUpdateBy, String command) throws InvalidArgumentException {
         String alertText = "";
-        int newQuantity = item.getItemQuantity();
+        int currentQuantity = item.getItemQuantity();
 
-        if (command.trim().equals(RestockCommand.COMMAND.trim())) {
-            if (itemQuantity > 0) {
-                newQuantity += itemQuantity;
+        switch (command) {
+        case RestockCommand.COMMAND:
+            if (quantityToUpdateBy > 0) {
+                currentQuantity += quantityToUpdateBy;
+                item.setItemQuantity(currentQuantity);
             } else {
                 throw new InvalidArgumentException("Please provide a positive number.");
             }
 
             int totalUnitsPurchased = item.getTotalUnitsPurchased();
-            item.setTotalUnitsPurchased(totalUnitsPurchased + itemQuantity);
-        } else {
-            if (newQuantity >= itemQuantity && itemQuantity > 0) {
-                newQuantity -= itemQuantity;
-            } else if (itemQuantity <= 0) {
+            item.setTotalUnitsPurchased(totalUnitsPurchased + quantityToUpdateBy);
+
+            break;
+        case SellCommand.COMMAND:
+            if (quantityToUpdateBy <= 0) {
                 throw new InvalidArgumentException("Please provide a positive number.");
-            } else {
+            }
+            if (quantityToUpdateBy > currentQuantity) {
                 throw new InvalidArgumentException("You do not have enough to sell the stated quantity.");
             }
+            currentQuantity -= quantityToUpdateBy;
+            item.setItemQuantity(currentQuantity);
 
             RetailItem retailItem = (RetailItem)item;
             int itemThreshold = retailItem.getItemThreshold();
 
-            if (newQuantity < itemThreshold) {
+            if (currentQuantity < itemThreshold) {
                 alertText = alertItemQuantity(retailItem);
             }
 
             int totalUnitsSold = retailItem.getTotalUnitsSold();
-            retailItem.setTotalUnitsSold(totalUnitsSold + itemQuantity);
+            retailItem.setTotalUnitsSold(totalUnitsSold + quantityToUpdateBy);
+            break;
         }
-        item.setItemQuantity(newQuantity);
+
         String output = "Great! I have updated the quantity of the item for you:" + System.lineSeparator()
                 + System.lineSeparator() + item
                 + alertText;
-
 
         return output;
     }
@@ -370,15 +376,17 @@ public class ItemList {
      * @throws InvalidArgumentException If provided item quantity is invalid (out of bounds).
      */
     public String sellOrRestockItem(String itemName, int itemQuantity, String command) throws InvalidArgumentException{
-        String output = "Sorry, I can't find the item you are looking for.";
+        Item item = null;
 
-        for (Item item : itemList) {
-            if (!item.getItemName().trim().equals(itemName.trim())) {
-                continue;
-            }
-            output = sellOrRestock(item, itemQuantity, command);
-            break;
+        // Temporary for now. I noticed that both InvalidCommandException and InvalidArgumentException are used
+        // in this class. Would like to clarify which we are intending to use.
+        try {
+            item = findItemByName(itemName);
+        } catch (InvalidCommandException e) {
+            throw new InvalidArgumentException(e.getMessage());
         }
+        String output = sellOrRestock(item, itemQuantity, command);
+
         return output;
     }
 
@@ -392,7 +400,7 @@ public class ItemList {
      * @throws InvalidArgumentException If provided item quantity is invalid (out of bounds).
      */
     public String sellOrRestockItem(int index, int itemQuantity, String command) throws InvalidArgumentException {
-        Item item = itemList.get(index - 1);
+        Item item = itemList.get(sortedOrder.get(index - 1));
         return sellOrRestock(item, itemQuantity, command);
     }
 
@@ -403,7 +411,6 @@ public class ItemList {
      * @param item The Item to be flagged out.
      * @return A String result which indicates that the Item's quantity has fallen below its threshold.
      */
-
     public String alertItemQuantity(Item item) {
         item.setAlert(true);
         String output = System.lineSeparator() + System.lineSeparator() + "Oh no! Your item is running low!";

--- a/src/test/java/seedu/binbash/command/RestockCommandTest.java
+++ b/src/test/java/seedu/binbash/command/RestockCommandTest.java
@@ -3,7 +3,6 @@ package seedu.binbash.command;
 import org.junit.jupiter.api.Test;
 import seedu.binbash.inventory.ItemList;
 import seedu.binbash.exceptions.InvalidCommandException;
-import seedu.binbash.exceptions.InvalidArgumentException;
 import seedu.binbash.item.Item;
 
 import java.time.LocalDate;
@@ -11,7 +10,6 @@ import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RestockCommandTest {
 

--- a/src/test/java/seedu/binbash/command/RestockCommandTest.java
+++ b/src/test/java/seedu/binbash/command/RestockCommandTest.java
@@ -3,6 +3,7 @@ package seedu.binbash.command;
 import org.junit.jupiter.api.Test;
 import seedu.binbash.inventory.ItemList;
 import seedu.binbash.exceptions.InvalidCommandException;
+import seedu.binbash.exceptions.InvalidArgumentException;
 import seedu.binbash.item.Item;
 
 import java.time.LocalDate;
@@ -10,6 +11,7 @@ import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RestockCommandTest {
 
@@ -34,5 +36,52 @@ public class RestockCommandTest {
 
         assertTrue(restockCommand.execute(itemList));
         assertEquals(0, itemList.getItemCount());
+    }
+
+    @Test
+    public void restockItem_returnsErrorMessage_negativeQuantity() {
+        ItemList itemList = new ItemList(new ArrayList<>());
+        itemList.addItem("retail", "Test Item", "Test Description", 10, LocalDate.MIN, 5.0, 2.0, 5);
+        RestockCommand command = new RestockCommand("Test Item", -5);
+        command.execute(itemList);
+        assertEquals("Please provide a positive number.", command.getExecutionUiOutput());
+    }
+
+    @Test
+    public void restockItem_increasesQuantity_validIndexAndQuantity() {
+        ItemList itemList = new ItemList(new ArrayList<>());
+        itemList.addItem("retail", "Test Item", "Test Description", 10, LocalDate.MIN, 5.0, 2.0, 5);
+        RestockCommand command = new RestockCommand(1, 5);
+        command.setIsIndex();
+        command.execute(itemList);
+        assertEquals(15, itemList.getItemList().get(0).getItemQuantity());
+    }
+
+    @Test
+    public void restockItem_returnsErrorMessage_negativeQuantityByIndex() {
+        ItemList itemList = new ItemList(new ArrayList<>());
+        itemList.addItem("retail", "Test Item", "Test Description", 10, LocalDate.MIN, 5.0, 2.0, 5);
+        RestockCommand command = new RestockCommand(1, -5);
+        command.setIsIndex();
+        command.execute(itemList);
+        assertEquals("Please provide a positive number.", command.getExecutionUiOutput());
+    }
+
+    @Test
+    public void restockItem_returnsErrorMessage_nonExistingItem() {
+        ItemList itemList = new ItemList(new ArrayList<>());
+        RestockCommand command = new RestockCommand("Non-Existing Item", 5);
+        command.execute(itemList);
+        assertEquals("Item with name 'Non-Existing Item' not found.", command.getExecutionUiOutput());
+    }
+
+    @Test
+    public void restockItem_returnsErrorMessage_invalidIndex() {
+        ItemList itemList = new ItemList(new ArrayList<>());
+        itemList.addItem("retail", "Test Item", "Test Description", 10, LocalDate.MIN, 5.0, 2.0, 5);
+        RestockCommand command = new RestockCommand(2, 5);
+        command.setIsIndex();
+        command.execute(itemList);
+        assertEquals("Index entered is out of bounds!", command.getExecutionUiOutput());
     }
 }

--- a/src/test/java/seedu/binbash/command/SellCommandTest.java
+++ b/src/test/java/seedu/binbash/command/SellCommandTest.java
@@ -26,7 +26,7 @@ public class SellCommandTest {
         Item updatedItem = itemList.findItemByName(itemName);
         assertEquals(4, updatedItem.getItemQuantity());
     }
-    
+
     @Test
     void execute_itemNotFound_noChangeInItemList() {
         ItemList itemList = new ItemList(new ArrayList<Item>());

--- a/src/test/java/seedu/binbash/command/SellCommandTest.java
+++ b/src/test/java/seedu/binbash/command/SellCommandTest.java
@@ -26,7 +26,7 @@ public class SellCommandTest {
         Item updatedItem = itemList.findItemByName(itemName);
         assertEquals(4, updatedItem.getItemQuantity());
     }
-
+    
     @Test
     void execute_itemNotFound_noChangeInItemList() {
         ItemList itemList = new ItemList(new ArrayList<Item>());
@@ -34,5 +34,52 @@ public class SellCommandTest {
 
         assertTrue(restockCommand.execute(itemList));
         assertEquals(0, itemList.getItemCount());
+    }
+
+    @Test
+    public void sellItem_returnsErrorMessage_negativeQuantity() {
+        ItemList itemList = new ItemList(new ArrayList<>());
+        itemList.addItem("retail", "Test Item", "Test Description", 10, LocalDate.MIN, 5.0, 2.0, 5);
+        SellCommand command = new SellCommand("Test Item", -5);
+        command.execute(itemList);
+        assertEquals("Please provide a positive number.", command.getExecutionUiOutput());
+    }
+
+    @Test
+    public void sellItem_decreasesQuantity_validIndexAndQuantity() {
+        ItemList itemList = new ItemList(new ArrayList<>());
+        itemList.addItem("retail", "Test Item", "Test Description", 10, LocalDate.MIN, 5.0, 2.0, 5);
+        SellCommand command = new SellCommand(1, 5);
+        command.setIsIndex();
+        command.execute(itemList);
+        assertEquals(5, itemList.getItemList().get(0).getItemQuantity());
+    }
+
+    @Test
+    public void sellItem_returnsErrorMessage_negativeQuantityByIndex() {
+        ItemList itemList = new ItemList(new ArrayList<>());
+        itemList.addItem("retail", "Test Item", "Test Description", 10, LocalDate.MIN, 5.0, 2.0, 5);
+        SellCommand command = new SellCommand(1, -5);
+        command.setIsIndex();
+        command.execute(itemList);
+        assertEquals("Please provide a positive number.", command.getExecutionUiOutput());
+    }
+
+    @Test
+    public void sellItem_returnsErrorMessage_nonExistingItem() {
+        ItemList itemList = new ItemList(new ArrayList<>());
+        SellCommand command = new SellCommand("Non-Existing Item", 5);
+        command.execute(itemList);
+        assertEquals("Item with name 'Non-Existing Item' not found.", command.getExecutionUiOutput());
+    }
+
+    @Test
+    public void sellItem_returnsErrorMessage_invalidIndex() {
+        ItemList itemList = new ItemList(new ArrayList<>());
+        itemList.addItem("retail", "Test Item", "Test Description", 10, LocalDate.MIN, 5.0, 2.0, 5);
+        SellCommand command = new SellCommand(2, 5);
+        command.setIsIndex();
+        command.execute(itemList);
+        assertEquals("Index entered is out of bounds!", command.getExecutionUiOutput());
     }
 }


### PR DESCRIPTION
`sell` and `restock` commands now take effect on the sorted list, the list which is stored after calling a `list` command.

This is to be consistent with the already existing "list then `delete`/`update`" behaviour.

Do assist in checking if the functionality remains the same!

Towards #184 